### PR TITLE
experimental stm32f4 support

### DIFF
--- a/README
+++ b/README
@@ -13,49 +13,57 @@ use that to check for updates.
 Currently Supported Chips
 =========================
 8051 based controllers:
-    at89c51snd1c       at89c51snd2c       at89c5130          at89c5131       
-    at89c5132       
+    at89c51snd1c       at89c51snd2c       at89c5130          at89c5131
+    at89c5132
 AVR based controllers:
-    at90usb1287        at90usb1286        at90usb1287-4k     at90usb1286-4k  
-    at90usb647         at90usb646         at90usb162         at90usb82       
-    atmega32u6         atmega32u4         atmega32u2         atmega16u4      
-    atmega16u2         atmega8u2       
+    at90usb1287        at90usb1286        at90usb1287-4k     at90usb1286-4k
+    at90usb647         at90usb646         at90usb162         at90usb82
+    atmega32u6         atmega32u4         atmega32u2         atmega16u4
+    atmega16u2         atmega8u2
 AVR32 based controllers:
-    at32uc3a0128       at32uc3a1128       at32uc3a0256       at32uc3a1256    
-    at32uc3a0512       at32uc3a1512       at32uc3a0512es     at32uc3a1512es  
-    at32uc3a364        at32uc3a364s       at32uc3a3128       at32uc3a3128s   
-    at32uc3a3256       at32uc3a3256s      at32uc3a4256s      at32uc3b064     
-    at32uc3b164        at32uc3b0128       at32uc3b1128       at32uc3b0256    
-    at32uc3b1256       at32uc3b0256es     at32uc3b1256es     at32uc3b0512    
-    at32uc3b1512       at32uc3c064        at32uc3c0128       at32uc3c0256    
-    at32uc3c0512       at32uc3c164        at32uc3c1128       at32uc3c1256    
-    at32uc3c1512       at32uc3c264        at32uc3c2128       at32uc3c2256    
-    at32uc3c2512    
+    at32uc3a0128       at32uc3a1128       at32uc3a0256       at32uc3a1256
+    at32uc3a0512       at32uc3a1512       at32uc3a0512es     at32uc3a1512es
+    at32uc3a364        at32uc3a364s       at32uc3a3128       at32uc3a3128s
+    at32uc3a3256       at32uc3a3256s      at32uc3a4256s      at32uc3b064
+    at32uc3b164        at32uc3b0128       at32uc3b1128       at32uc3b0256
+    at32uc3b1256       at32uc3b0256es     at32uc3b1256es     at32uc3b0512
+    at32uc3b1512       at32uc3c064        at32uc3c0128       at32uc3c0256
+    at32uc3c0512       at32uc3c164        at32uc3c1128       at32uc3c1256
+    at32uc3c1512       at32uc3c264        at32uc3c2128       at32uc3c2256
+    at32uc3c2512
 XMEGA based controllers:
-    atxmega64a1u       atxmega128a1u      atxmega64a3u       atxmega128a3u   
-    atxmega192a3u      atxmega256a3u      atxmega16a4u       atxmega32a4u    
-    atxmega64a4u       atxmega128a4u      atxmega256a3bu     atxmega64b1     
-    atxmega128b1       atxmega64b3        atxmega128b3       atxmega64c3     
-    atxmega128c3       atxmega256c3       atxmega384c3       atxmega16c4     
-    atxmega32c4     
+    atxmega64a1u       atxmega128a1u      atxmega64a3u       atxmega128a3u
+    atxmega192a3u      atxmega256a3u      atxmega16a4u       atxmega32a4u
+    atxmega64a4u       atxmega128a4u      atxmega256a3bu     atxmega64b1
+    atxmega128b1       atxmega64b3        atxmega128b3       atxmega64c3
+    atxmega128c3       atxmega256c3       atxmega384c3       atxmega16c4
+    atxmega32c4
+
+Experimental support for ST cortex M4:
+    stm32f4_B          stm32f4_C          stm32f4_E          stm32f4_G
 
 
 Simple install procedure for Unix/Linux/MAC
 ===========================================
 
   % tar -xzf dfu-programmer-<version>.tar.gz    # unpack the sources
-  % cd dfu-programmer                           # change to the top-level
-                                                # directory
+            -- or --
+  % git clone https://github.com/dfu-programmer/dfu-programmer.git
+
+  % cd dfu-programmer       # change to the top-level directory
 
   [ If the source was checked-out from GitHub, run the following command.
     You may also need to do this if your libusb is in a non-standard location,
     or if the build fails to find it for some reason.  This command requires
     that autoconf is installed (sudo apt-get install autoconf) ]
-  % ./bootstrap.sh                              # regenerate base config
-                                                # files
 
-  % ./configure                                 # regenerate configure and
-                                                # run it
+  % ./bootstrap.sh          # regenerate base config files
+
+
+  [ Optionally you can add autocompletion using the dfu_completion file,
+    and possibly instructions provided after running the ./bootstrap command ]
+
+  % ./configure             # regenerate configure and run it
 
   [ Optionally you can specify where dfu-programmer gets installed
     using the --prefix= option to the ./configure command.  See
@@ -68,9 +76,10 @@ Simple install procedure for Unix/Linux/MAC
     it is not. You can select libusb using --disable-libusb_1_0. If
     usb library is not available try getting libusb-1.0-0-dev ]
 
-    % make                                      # build dfu-programmer
+  % make                    # build dfu-programmer
+
   [ Become root if necessary ]
-  % make install                                # install dfu-programmer
+  % make install            # install dfu-programmer
 
 Build procedure for Windows
 ===========================

--- a/docs/dfu-programmer.1
+++ b/docs/dfu-programmer.1
@@ -61,6 +61,8 @@ atxmega64a4u, atxmega128a4u, atxmega256a3bu, atxmega64b1,
 atxmega128b1, atxmega64b3, atxmega128b3, atxmega64c3,
 atxmega128c3, atxmega256c3, atxmega384c3, atxmega16c4,
 atxmega32c4
+.IP "STM32F4 controllers (experimental):"
+stm32f4_B, stm32f4_C, stm32f4_E, stm32f4_G
 
 .SH USAGE
 There are no mechanisms to implement gang programming.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,5 +2,5 @@ AM_CFLAGS = -Wall
 bin_PROGRAMS = dfu-programmer
 dfu_programmer_SOURCES = main.c arguments.c arguments.h atmel.c atmel.h \
                          commands.c commands.h dfu.c dfu.h dfu-bool.h \
-                         dfu-device.h intel_hex.c intel_hex.h util.c util.h
-
+                         dfu-device.h intel_hex.c intel_hex.h stm32.c stm32.h \
+                         util.c util.h

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -51,6 +51,8 @@
 #define BL_EXTRA        2   /* Bootloader at top in separate memory area */
 #define BL_SPECIFIC     3   /* Any value greater than this is a specific start address */
 
+extern int debug;       /* defined in main.c */
+
 struct option_mapping_structure {
     const char *name;
     int32_t value;

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -172,6 +172,12 @@ static struct target_mapping_structure target_map[] = {
     { "atxmega384c3",   tar_atxmega384c3,   ADC_XMEGA, 0x2FDB, 0x03eb, 0x60000, 0x2000, BL_EXTRA,  512,  32, 0x1000 },
     { "atxmega16c4",    tar_atxmega16c4,    ADC_XMEGA, 0x2FD8, 0x03eb,  0x4000, 0x1000, BL_EXTRA,  256,  32,  0x400 },
     { "atxmega32c4",    tar_atxmega32c4,    ADC_XMEGA, 0x2FD9, 0x03eb,  0x8000, 0x1000, BL_EXTRA,  256,  32,  0x400 },
+    // Name             ID (arguments.h)    DevType    PID     VID     MemSize  BootSz  BootLoc  FPage EPage  ESize
+    // NOTE : that support for these targets is experimental but has been tested with stm32f4 chips on ubuntu
+    { "stm32f4_B",      tar_stm32f4_B,      DC_STM32,  0xdf11, 0x0483, 0x20000, 0x0000, BL_EXTRA,  512,   0,      0 },
+    { "stm32f4_C",      tar_stm32f4_C,      DC_STM32,  0xdf11, 0x0483, 0x40000, 0x0000, BL_EXTRA,  512,   0,      0 },
+    { "stm32f4_E",      tar_stm32f4_E,      DC_STM32,  0xdf11, 0x0483, 0x80000, 0x0000, BL_EXTRA,  512,   0,      0 },
+    { "stm32f4_G",      tar_stm32f4_G,      DC_STM32,  0xdf11, 0x0483, 0x100000,0x0000, BL_EXTRA,  512,   0,      0 },
     { NULL }
     // END_TARGET_LIST_LINE .. used for autocompletion script
 };
@@ -464,6 +470,7 @@ static int32_t assign_target( struct programmer_arguments *args,
                 args->memory_address_bottom = args->flash_address_bottom;
                 args->memory_address_top = args->bootloader_top;
             }
+
             switch( args->device_type ) {
                 case ADC_8051:
                     strncpy( args->device_type_string, "8051",
@@ -488,6 +495,14 @@ static int32_t assign_target( struct programmer_arguments *args,
                              DEVICE_TYPE_STRING_MAX_LENGTH );
                     args->initial_abort = true;
                     //args->honor_interfaceclass = false;
+                    break;
+                case DC_STM32:
+                    strncpy( args->device_type_string, "STM32",
+                             DEVICE_TYPE_STRING_MAX_LENGTH );
+                    break;
+                default :
+                    strncpy( args->device_type_string, "UNKNO",
+                             DEVICE_TYPE_STRING_MAX_LENGTH );
                     break;
             }
             /* There have been several reports on the mailing list of dfu-programmer

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -37,18 +37,16 @@
  *  launch [--no-reset]
  */
 
-// ERROR CODES :
-#define SUCCESS                             0
-#define UNSPECIFIED_ERROR                   1
-#define ARGUMENT_ERROR                      2
-#define DEVICE_ACCESS_ERROR                 3
-#define BUFFER_INIT_ERROR                   4
-#define FLASH_READ_ERROR                    5
-#define FLASH_WRITE_ERROR                   6
-#define VALIDATION_ERROR_IN_REGION          7
-#define VALIDATION_ERROR_OUTSIDE_REGION     8
-
-extern int debug;
+enum return_codes_enum {
+    SUCCESS = 0,
+    UNSPECIFIED_ERROR,                  /* general error */
+    ARGUMENT_ERROR,                     /* invalid command for target etc. */
+    DEVICE_ACCESS_ERROR,                /* security bit etc. */
+    BUFFER_INIT_ERROR,                  /* hex files problems etc. */
+    FLASH_READ_ERROR,
+    FLASH_WRITE_ERROR,
+    VALIDATION_ERROR_IN_REGION,
+    VALIDATION_ERROR_OUTSIDE_REGION };
 
 enum targets_enum { tar_at89c51snd1c,
                     tar_at89c51snd2c,

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -127,6 +127,10 @@ enum targets_enum { tar_at89c51snd1c,
                     tar_atxmega384c3,
                     tar_atxmega16c4,
                     tar_atxmega32c4,
+                    tar_stm32f4_B,
+                    tar_stm32f4_C,
+                    tar_stm32f4_E,
+                    tar_stm32f4_G,
                     tar_none };
 
 enum commands_enum { com_none, com_erase, com_flash, com_user, com_eflash,

--- a/src/atmel.c
+++ b/src/atmel.c
@@ -69,7 +69,7 @@
 #define PROGRESS_END    "]  "
 #define PROGRESS_ERROR  " X  "
 
-extern int debug;
+extern int debug;       /* defined in main.c */
 
 // ________  P R O T O T Y P E S  _______________________________
 static int32_t atmel_read_command( dfu_device_t *device,
@@ -218,13 +218,13 @@ int32_t atmel_read_fuses( dfu_device_t *device,
 
     if( NULL == device ) {
         DEBUG( "invalid arguments.\n" );
-        return -1;
+        return ARGUMENT_ERROR;
     }
 
     if( !(ADC_AVR32 & device->type) ) {
         DEBUG( "target does not support fuse operation.\n" );
         fprintf( stderr, "target does not support fuse operation.\n" );
-        return -1;
+        return ARGUMENT_ERROR;
     }
 
     if( 0 != atmel_select_memory_unit(device, mem_config) ) {

--- a/src/atmel.c
+++ b/src/atmel.c
@@ -81,7 +81,7 @@ static int32_t atmel_read_command( dfu_device_t *device,
  */
 
 static int32_t __atmel_flash_block( dfu_device_t *device,
-                                    atmel_buffer_out_t *bout,
+                                    intel_buffer_out_t *bout,
                                     const dfu_bool eeprom );
 /* flash the contents of memory into a block of memory.  it is assumed that the
  * appropriate page has already been selected.  start and end are the start and
@@ -112,15 +112,8 @@ static int32_t __atmel_blank_page_check( dfu_device_t *device,
  * returns a negative number if the blank check fails
  */
 
-static int32_t atmel_flash_prep_buffer( atmel_buffer_out_t *bout );
-/* prepare the buffer so that valid data fills each page that contains data.
- * unassigned data in buffer is given a value of 0xff (blank memory)
- * the buffer pointer must align with the beginning of a flash page
- * return 0 on success, -1 if assigning data would extend flash above size
- */
-
 static int32_t __atmel_read_block( dfu_device_t *device,
-                                   atmel_buffer_in_t *buin,
+                                   intel_buffer_in_t *buin,
                                    const dfu_bool eeprom );
 /* assumes block does not cross 64 b page boundaries and ideally alligs
  * with flash pages. appropriate memory type and 64kb page has already
@@ -128,7 +121,7 @@ static int32_t __atmel_read_block( dfu_device_t *device,
  * data between data_start and data_end
  */
 
-static inline void __print_progress( atmel_buffer_info_t *info,
+static inline void __print_progress( intel_buffer_info_t *info,
                                         uint32_t *progress );
 /* calculate how many progress indicator steps to print and print them
  * update progress value
@@ -138,7 +131,7 @@ static inline void __print_progress( atmel_buffer_info_t *info,
 static int32_t atmel_read_command( dfu_device_t *device,
                                    const uint8_t data0,
                                    const uint8_t data1 ) {
-    atmel_buffer_in_t buin;
+    intel_buffer_in_t buin;
     uint8_t buffer[4];
 
     TRACE( "%s( %p, 0x%02x, 0x%02x )\n", __FUNCTION__, device, data0, data1 );
@@ -202,7 +195,7 @@ static int32_t atmel_read_command( dfu_device_t *device,
     }
 }
 
-static inline void __print_progress( atmel_buffer_info_t *info,
+static inline void __print_progress( intel_buffer_info_t *info,
                                         uint32_t *progress ) {
     if ( !(debug > ATMEL_DEBUG_THRESHOLD) ) {
         while ( ((info->block_end - info->data_start + 1) * 32) > *progress ) {
@@ -212,117 +205,9 @@ static inline void __print_progress( atmel_buffer_info_t *info,
     }
 }
 
-int32_t atmel_validate_buffer( atmel_buffer_in_t *buin,
-                               atmel_buffer_out_t *bout,
-                               dfu_bool quiet) {
-    int32_t i;
-    int32_t invalid_data_region = 0;
-    int32_t invalid_outside_data_region = 0;
-
-    DEBUG( "Validating image from byte 0x%X to 0x%X.\n",
-            bout->info.valid_start, bout->info.valid_end );
-
-    if( !quiet ) fprintf( stderr, "Validating...  " );
-    for( i = bout->info.valid_start; i <= bout->info.valid_end; i++ ) {
-        if(  bout->data[i] <= UINT8_MAX ) {
-            // Memory should have been programmed here
-            if( ((uint8_t) bout->data[i]) != buin->data[i] ) {
-                if ( !invalid_data_region ) {
-                    if( !quiet ) fprintf( stderr, "ERROR\n" );
-                    DEBUG( "Image did not validate at byte: 0x%X of 0x%X.\n", i,
-                            bout->info.valid_end - bout->info.valid_start + 1 );
-                    DEBUG( "Wanted 0x%02x but read 0x%02x.\n",
-                            0xff & bout->data[i], buin->data[i] );
-                    DEBUG( "suppressing additional warnings.\n");
-                }
-                invalid_data_region++;
-            }
-        } else {
-            // Memory should be blank here
-            if( 0xff != buin->data[i] ) {
-                if ( !invalid_data_region ) {
-                    DEBUG( "Outside program region: byte 0x%X epected 0xFF.\n", i);
-                    DEBUG( "but read 0x%02X.  supressing additional warnings.\n",
-                            buin->data[i] );
-                }
-                invalid_outside_data_region++;
-            }
-        }
-    }
-
-    if( !quiet ) {
-        if ( 0 == invalid_data_region + invalid_outside_data_region ) {
-            fprintf( stderr, "Success\n" );
-        } else {
-            fprintf( stderr,
-                    "%d invalid bytes in program region, %d outside region.\n",
-                    invalid_data_region, invalid_outside_data_region );
-        }
-    }
-
-    return invalid_data_region ?
-        -1 * invalid_data_region : invalid_outside_data_region;
-}
-
-int32_t atmel_init_buffer_out(atmel_buffer_out_t *bout,
-        size_t total_size, size_t page_size ) {
-    uint32_t i;
-    if ( !total_size || !page_size ) {
-        DEBUG("What are you thinking... size must be > 0.\n");
-        return -1;
-    }
-
-    bout->info.total_size = total_size;
-    bout->info.page_size = page_size;
-    bout->info.data_start = UINT32_MAX;      // invalid data start
-    bout->info.data_end = 0;
-    bout->info.valid_start = 0;
-    bout->info.valid_end = total_size - 1;
-    bout->info.block_start = 0;
-    bout->info.block_end = 0;
-    // allocate the memory
-    bout->data = (uint16_t *) malloc( total_size * sizeof(uint16_t) );
-    if( NULL == bout->data ) {
-        DEBUG( "ERROR allocating 0x%X bytes of memory.\n",
-                total_size * sizeof(uint16_t));
-        return -2;
-    }
-
-    // initialize buffer to 0xFFFF (invalid / unassigned data)
-    for( i = 0; i < total_size; i++ ) {
-        bout->data[i] = UINT16_MAX;
-    }
-    return 0;
-}
-
-int32_t atmel_init_buffer_in(atmel_buffer_in_t *buin,
-        size_t total_size, size_t page_size ) {
-    // TODO : is there a way to combine this and above? maybe typecast to an
-    // in or out buffer from a char pointer?
-    buin->info.total_size = total_size;
-    buin->info.page_size = page_size;
-    buin->info.data_start = 0;
-    buin->info.data_end = total_size - 1;
-    buin->info.valid_start = 0;
-    buin->info.valid_end = total_size - 1;
-    buin->info.block_start = 0;
-    buin->info.block_end = 0;
-
-    buin->data = (uint8_t *) malloc( total_size );
-    if( NULL == buin->data ) {
-        DEBUG( "ERROR allocating 0x%X bytes of memory.\n", total_size );
-        return -2;
-    }
-
-    // initialize buffer to 0xFF (blank / unassigned data)
-    memset( buin->data, UINT8_MAX, total_size );
-
-    return 0;
-}
-
 int32_t atmel_read_fuses( dfu_device_t *device,
                            atmel_avr32_fuses_t *info ) {
-    atmel_buffer_in_t buin;
+    intel_buffer_in_t buin;
     uint8_t buffer[32];
     int i;
 
@@ -516,7 +401,7 @@ int32_t atmel_set_fuse( dfu_device_t *device,
     int32_t address;
     int8_t numbytes;
     int8_t i;
-    atmel_buffer_out_t bout;
+    intel_buffer_out_t bout;
 
     if( NULL == device ) {
         DEBUG( "invalid arguments.\n" );
@@ -687,7 +572,7 @@ int32_t atmel_set_config( dfu_device_t *device,
 }
 
 static int32_t __atmel_read_block( dfu_device_t *device,
-                                   atmel_buffer_in_t *buin,
+                                   intel_buffer_in_t *buin,
                                    const dfu_bool eeprom ) {
     uint8_t command[6] = { 0x03, 0x00, 0x00, 0x00, 0x00, 0x00 };
     int32_t result;
@@ -743,7 +628,7 @@ static int32_t __atmel_read_block( dfu_device_t *device,
 }
 
 int32_t atmel_read_flash( dfu_device_t *device,
-                          atmel_buffer_in_t *buin,
+                          intel_buffer_in_t *buin,
                           const uint8_t mem_segment,
                           const dfu_bool quiet ) {
     uint8_t mem_page = 0;           // tracks the current memory page
@@ -1151,35 +1036,7 @@ static int32_t atmel_select_page( dfu_device_t *device,
     return 0;
 }
 
-static int32_t atmel_flash_prep_buffer( atmel_buffer_out_t *bout ) {
-    uint16_t *page;
-    int32_t i;
-
-    TRACE( "%s( %p )\n", __FUNCTION__, bout );
-
-    // increment pointer by page_size * sizeof(int16) until page_start >= end
-    for( page = bout->data;
-            page < &bout->data[bout->info.valid_end];
-            page = &page[bout->info.page_size] ) {
-        // check if there is valid data on this page
-        for( i = 0; i < bout->info.page_size; i++ ) {
-            if( page[i] <= UINT8_MAX )
-                break;
-        }
-
-        if( bout->info.page_size != i ) {
-            /* There was valid data in the block & we need to make
-             * sure there is no unassigned data.  */
-            for( i = 0; i < bout->info.page_size; i++ ) {
-                if( page[i] > UINT8_MAX )
-                    page[i] = 0xff;         // 0xff is blank
-            }
-        }
-    }
-    return 0;
-}
-
-int32_t atmel_user( dfu_device_t *device, atmel_buffer_out_t *bout ) {
+int32_t atmel_user( dfu_device_t *device, intel_buffer_out_t *bout ) {
     int32_t result = 0;
 
     TRACE( "%s( %p, %p )\n", __FUNCTION__, device, bout );
@@ -1214,7 +1071,7 @@ int32_t atmel_user( dfu_device_t *device, atmel_buffer_out_t *bout ) {
 int32_t atmel_secure( dfu_device_t *device ) {
     int32_t result = 0;
     uint16_t buffer[1];
-    atmel_buffer_out_t bout;
+    intel_buffer_out_t bout;
     TRACE( "%s( %p )\n", __FUNCTION__, device );
 
     /* Select SECURITY page */
@@ -1245,7 +1102,7 @@ int32_t atmel_getsecure( dfu_device_t *device ) {
     uint8_t buffer[1];
     TRACE( "%s( %p )\n", __FUNCTION__, device );
 
-    atmel_buffer_in_t buin;
+    intel_buffer_in_t buin;
 
     // init the necessary parts of buin
     buin.info.block_start = 0;
@@ -1280,7 +1137,7 @@ int32_t atmel_getsecure( dfu_device_t *device ) {
 }
 
 int32_t atmel_flash( dfu_device_t *device,
-                     atmel_buffer_out_t *bout,
+                     intel_buffer_out_t *bout,
                      const dfu_bool eeprom,
                      const dfu_bool force,
                      const dfu_bool quiet ) {
@@ -1311,7 +1168,7 @@ int32_t atmel_flash( dfu_device_t *device,
     // for each page with data, fill unassigned values on the page with 0xFF
     // bout->data[0] always aligns with a flash page boundary irrespective
     // of where valid_start is located
-    if( 0 != atmel_flash_prep_buffer( bout ) ) {
+    if( 0 != intel_flash_prep_buffer( bout ) ) {
         if( !quiet )
             fprintf( stderr, "Program Error, use debug for more info.\n" );
         return -2;
@@ -1547,7 +1404,7 @@ static void atmel_flash_populate_header( uint8_t *header,
 }
 
 static int32_t __atmel_flash_block( dfu_device_t *device,
-                                    atmel_buffer_out_t *bout,
+                                    intel_buffer_out_t *bout,
                                     const dfu_bool eeprom ) {
     // from doc7618, AT90 / ATmega app note protocol:
     const size_t length = bout->info.block_end - bout->info.block_start + 1;
@@ -1601,8 +1458,8 @@ static int32_t __atmel_flash_block( dfu_device_t *device,
     /* for programming flash or eeprom for xmega or avr32, header[1] = 0x00 */
     /* for programming eeprom, memory was selected in atmel_flash */
     if( ADC_XMEGA & device->type ) {
-	header[1] = 0x00; 
-    } 
+	header[1] = 0x00;
+    }
 
     // Copy the data
     for( i = 0; i < length; i++ ) {

--- a/src/commands.c
+++ b/src/commands.c
@@ -122,10 +122,10 @@ static int32_t execute_setsecure( dfu_device_t *device,
     if( result < 0 ) {
         DEBUG( "Error while setting security bit. (%d)\n", result );
         fprintf( stderr, "Error setting security bit.\n" );
-        return -1;
+        return UNSPECIFIED_ERROR;
     }
 
-    return 0;
+    return SUCCESS;
 }
 
 // TODO : split this into a new command (no file is needed) - also general
@@ -151,11 +151,11 @@ static int32_t serialize_memory_image( intel_buffer_out_t *bout,
         for( i=0; i < length; ++i ) {
             if ( 0 != intel_process_data(bout, serial_data[i],
                         target_offset, offset + i) ) {
-                return -1;
+                return BUFFER_INIT_ERROR;
             }
         }
     }
-    return 0;
+    return SUCCESS;
 }
 
 static int32_t execute_validate( dfu_device_t *device,
@@ -241,7 +241,7 @@ static int32_t execute_flash( dfu_device_t *device,
         case mem_eeprom:
             if( 0 == args->eeprom_memory_size ) {
                 fprintf( stderr, "This device has no eeprom.\n" );
-                return -1;
+                return ARGUMENT_ERROR;
             }
             memory_size = args->eeprom_memory_size;
             page_size = args->eeprom_page_size;
@@ -259,7 +259,7 @@ static int32_t execute_flash( dfu_device_t *device,
             break;
         default:
             DEBUG("Unknown memory type %d\n", mem_type);
-            return -1;
+            return ARGUMENT_ERROR;
     }
 
     // ----------------- CONVERT HEX FILE TO BINARY -------------------------
@@ -422,7 +422,7 @@ static int32_t execute_getfuse( dfu_device_t *device,
     if( !(ADC_AVR32 & args->device_type) ) {
         DEBUG( "target doesn't support fuse set operation.\n" );
         fprintf( stderr, "target doesn't support fuse set operation.\n" );
-        return -1;
+        return ARGUMENT_ERROR;
     }
 
     /* Check AVR32 security bit in order to provide a better error message. */
@@ -431,7 +431,7 @@ static int32_t execute_getfuse( dfu_device_t *device,
     if( args->device_type & GRP_STM32 ) {
         fprintf( stderr, "Operation not supported on %s.\n",
                 args->device_type_string );
-        return -1;
+        return ARGUMENT_ERROR;
     } else {
         status = atmel_read_fuses( device, &info );
     }

--- a/src/commands.c
+++ b/src/commands.c
@@ -41,7 +41,7 @@ static int security_bit_state;
 
 // ________  P R O T O T Y P E S  _______________________________
 static int32_t execute_validate( dfu_device_t *device,
-                                 atmel_buffer_out_t *bout,
+                                 intel_buffer_out_t *bout,
                                  uint8_t mem_segment,
                                  dfu_bool quiet );
 /* provide an out buffer to validate and whether this is from
@@ -125,7 +125,7 @@ static int32_t execute_setsecure( dfu_device_t *device,
 // otherwise, the secion will end up '\0' unless a page erase is used.. so may
 // need to keep this part of the flash command, but specify that serialize data
 // 'wins' over data from the hex file
-static int32_t serialize_memory_image( atmel_buffer_out_t *bout,
+static int32_t serialize_memory_image( intel_buffer_out_t *bout,
                                      struct programmer_arguments *args ) {
     uint32_t target_offset = 0;
     if( args->command == com_user )
@@ -148,14 +148,14 @@ static int32_t serialize_memory_image( atmel_buffer_out_t *bout,
 }
 
 static int32_t execute_validate( dfu_device_t *device,
-                                 atmel_buffer_out_t *bout,
+                                 intel_buffer_out_t *bout,
                                  uint8_t mem_segment,
                                  const dfu_bool quiet ) {
     int32_t retval = UNSPECIFIED_ERROR;
     int32_t result;             // result of fcn calls
-    atmel_buffer_in_t buin;     // buffer in for storing read mem
+    intel_buffer_in_t buin;     // buffer in for storing read mem
 
-    if( 0 != atmel_init_buffer_in(&buin, bout->info.total_size,
+    if( 0 != intel_init_buffer_in(&buin, bout->info.total_size,
                                             bout->info.page_size ) ) {
         DEBUG("ERROR initializing a buffer.\n");
         retval = BUFFER_INIT_ERROR;
@@ -171,7 +171,7 @@ static int32_t execute_validate( dfu_device_t *device,
         goto error;
     }
 
-    if( 0 != (result = atmel_validate_buffer( &buin, bout, quiet )) ) {
+    if( 0 != (result = intel_validate_buffer( &buin, bout, quiet )) ) {
         if( result < 0 ) {
             retval = VALIDATION_ERROR_IN_REGION;
         } else {
@@ -193,7 +193,7 @@ error:
     return retval;
 }
 
-static void print_flash_usage( atmel_buffer_info_t *info ) {
+static void print_flash_usage( intel_buffer_info_t *info ) {
     fprintf( stderr,
             "0x%X bytes written into 0x%X bytes memory (%.02f%%).\n",
             info->data_end - info->data_start + 1,
@@ -207,7 +207,7 @@ static int32_t execute_flash( dfu_device_t *device,
     int32_t  retval = UNSPECIFIED_ERROR;
     int32_t  result;
     uint32_t  i;
-    atmel_buffer_out_t bout;
+    intel_buffer_out_t bout;
     size_t   memory_size;
     size_t   page_size;
     enum atmel_memory_unit_enum mem_type = args->com_flash_data.segment;
@@ -239,12 +239,12 @@ static int32_t execute_flash( dfu_device_t *device,
             }
             break;
         default:
-            memory_size = 0;
-            page_size = 0;
+            DEBUG("Unknown memory type %d\n", mem_type);
+            return -1;
     }
 
     // ----------------- CONVERT HEX FILE TO BINARY -------------------------
-    if( 0 != atmel_init_buffer_out(&bout, memory_size, page_size) ) {
+    if( 0 != intel_init_buffer_out(&bout, memory_size, page_size) ) {
         DEBUG("ERROR initializing a buffer.\n");
         retval = BUFFER_INIT_ERROR;
         goto error;
@@ -571,7 +571,7 @@ static int32_t execute_dump( dfu_device_t *device,
     int32_t i = 0;
     int32_t retval = UNSPECIFIED_ERROR;
     int32_t result;             // result of fcn calls
-    atmel_buffer_in_t buin;     // buffer in for storing read mem
+    intel_buffer_in_t buin;     // buffer in for storing read mem
     enum atmel_memory_unit_enum mem_segment = args->com_read_data.segment;
     size_t mem_size = 0;
     size_t page_size = 0;
@@ -600,7 +600,7 @@ static int32_t execute_dump( dfu_device_t *device,
             goto error;
     }
 
-    if( 0 != atmel_init_buffer_in(&buin, mem_size, page_size) ) {
+    if( 0 != intel_init_buffer_in(&buin, mem_size, page_size) ) {
         DEBUG("ERROR initializing a buffer.\n");
         retval = BUFFER_INIT_ERROR;
         goto error;

--- a/src/dfu-device.h
+++ b/src/dfu-device.h
@@ -17,10 +17,12 @@
 #define ADC_AVR     (1<<1)
 #define ADC_AVR32   (1<<2)
 #define ADC_XMEGA   (1<<3)
+#define DC_STM32    (1<<4)
 
 // Most commands fall into one of 2 groups.
 #define GRP_AVR32   (ADC_AVR32 | ADC_XMEGA)
 #define GRP_AVR     (ADC_AVR | ADC_8051)
+#define GRP_STM32   (DC_STM32)
 
 typedef unsigned atmel_device_class_t;
 
@@ -35,6 +37,108 @@ typedef struct {
 } dfu_device_t;
 
 #endif /* __DFU_DEVICE_H__ */
+
+/******************* S T M 3 2   D F U   C O M M A N D S ******************
+========= USB DFU Bootloader Requests ==============
+DFU_DETACH - [ 0x00 ]       wTimeout    interface   zero        none
+    > Requests the device to leave DFU mode and enter the application.
+    NOTE : The Detach request is not meaningful in the case of the bootloader.
+           The bootloader is started by a system reset depending on the boot
+           mode configuration settings, which means that no other application
+           is running at this time.
+DFU_DNLOAD - [ 0x01 ]       wBlockNum   interface   length      firmware
+    > Requests data transfer from Host to the device in order to load them
+      into device internal Flash. Includes also erase commands.
+DFU_UPLOAD - [ 0x02 ]       zero        interface   length      firmware
+    > Requests data transfer from device to Host in order to load content of
+      device internal Flash into a Host file.
+DFU_GETSTATUS - [ 0x03 ]    zero        interface   6           status
+    > Requests device to send status report to the Host (including status
+      resulting from the last request execution and the state the device will
+      enter immediately after this request).
+DFU_CLRSTATUS - [ 0x04 ]    zero        interface   zero        none
+    > Requests device to clear error status and move to next step.
+DFU_GETSTATE - [ 0x05 ]     zero        interface   1           state
+    > Requests the device to send only the state it will enter immediately
+      after this request.
+DFU_ABORT - [ 0x06 ]        zero        interface   zero        none
+    > Requests device to exit the current state/operation and enter idle
+      state immediately.
+
+========= STM32 DFU Commands ==============
+.                       DFU_UPLOAD  DFU_DNLOAD cmd
+.                       wValue      wValue  first byte
+READ MEMORY             > 1
+GET                     0
+WRITE MEMORY                        > 1
+ERASE                               0       0x41
+READ UNPROTECT                      0       0x92
+SET ADDRESS POINTER                 0       0x21
+LEAVE DFU MODE                      0       -- (0 data length)
+
+NOTES
+    > before issuing a DNLOAD request the host should check that the device
+      is in a correct sate dfuIDLE or dfuDNLOAD-IDLE and that there are no
+      errors.  if the device is not in the correct state a DFU_CLRSTATUS must
+      be called
+    > after a command is sent using DFU_DNLOAD, DFU_GETSTATUS must be called
+      to trigger command execution. a second DFU_GETSTATUS is required to
+      check for success (except when writing to the option bytes beacuse device
+      resets immediately after write)
+
+READ COMMAND        DFU_UPLOAD with wValue > 1
+    > host request device send a specified number of data bytes (wLength)
+      where wLength can be 2 to 2048 bytes, for option bytes read size should
+      be the option byte block size
+    > the address to read data from is computed using wBlockNumber (wValue)
+      and the address pointer using the formula:
+        addresss = ((wBlockNum - 2) x wTransferSize) + Address_Pointer
+        where: wTransferSize is the length of the requested data buffer
+    > the address should be previously specified using SET ADDRESS POINTER
+      otherwise the start of internal flash is assumed (0x0800000)
+
+GET COMMAND         DFU_UPLOAD with wValue = 0
+    > host sends DFU_UPLOAD command with wLength = 0, the device will return
+      N bytes representing the command codes where N = 4
+
+WRITE COMMAND       DFU_DNLOAD with wValue > 1
+    > in a write memory operation the write size can be from 2 to 2048 bytes
+      and the start address must be valid. when writing the option bytes the
+      start address must be the start of the option byte area and the size
+      should cover the entire option byte area
+    > the address is computed using the value of the wBlockNumber (wValue) and
+      the address pointer according the formula:
+        address = ((wBlockNum - 2) x wTransferSize) + Address_Pointer
+        where: wTransferSize is the length of the buffer sent by host
+               wBlockNumber is the value of wValue parameter
+
+SET ADDRESS POINTER - [ 0x21, mem ptr LSB A[7:0], A[8:15], A[23:16], A[31:24] ]
+    > wValue should be zero
+    > after sending the command host must send a DFU_GETSTATUS in order to
+      execute the command.  a second DFU_GETSTATUS is needed to check if the
+      command was correctly executed
+
+ERASE COMMAND       - [ 0x41, page LSB A[7:0], A[15:8], A[23:16], A[31:24] ]
+MASS ERASE          - [ 0x41 ]
+    > this can take a long time to execute so timeout should be long
+
+READ UNPROTECT      - [ 0x92 ]
+
+LEAVE DFU MODE      - DFU_DNLOAD with 0 data length
+    > device disconnect
+    > init registers of peripherals to default reset values
+    > initialize the user application main stack pointer
+    > jumps to memory location programmed in the received 'address pointer + 4'
+      which corresponds to the address of the application's reset handler
+
+    > the address pointer has to be set (using set address pointer) before
+      launching the LEAVE DFU command otherwise the bootloader will jump to the
+      default memory start address (0x0800000)
+
+- see an2606: STM32 microcontroller system memory boot mode
+- see an3156: USB DFU protocol used in the STM32 bootloader
+**************************************************************************/
+
 
 /******************* A T M E L   D F U   C O M M A N D S ******************
 // ---- A L L   D E V I C E S -----------------------------------

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -117,6 +117,17 @@ static void dfu_msg_response_output( const char *function, const int32_t result 
  */
 
 // ________  F U N C T I O N S  _______________________________
+void dfu_set_transaction_num( uint16_t newnum ) {
+    TRACE( "%s( %u )\n", __FUNCTION__, newnum );
+    transaction = newnum;
+    DEBUG("wValue set to %d\n", transaction);
+}
+
+uint16_t dfu_get_transaction_num( void ) {
+    TRACE( "%s( %u )\n", __FUNCTION__ );
+    return transaction;
+}
+
 int32_t dfu_detach( dfu_device_t *device, const int32_t timeout ) {
     int32_t result;
 
@@ -169,9 +180,6 @@ int32_t dfu_download( dfu_device_t *device,
     dfu_msg_response_output( __FUNCTION__, result );
 
     return result;
-// TODO : consider adding dfu_get_status here and returning status instead of
-// the length of the download? if there is a length mismatch on the download it
-// can be returned as -1.. this should simplify all calls to dfu_ from atmel_
 }
 
 int32_t dfu_upload( dfu_device_t *device, const size_t length, uint8_t* data ) {
@@ -792,6 +800,47 @@ static void dfu_msg_response_output( const char *function,
         msg = "No error.";
     } else {
         switch( result ) {
+#ifdef HAVE_LIBUSB_1_0
+            case LIBUSB_ERROR_IO :
+                msg = "LIBUSB_ERROR_IO: Input/output error.";
+                break;
+            case LIBUSB_ERROR_INVALID_PARAM :
+                msg = "LIBUSB_ERROR_INVALID_PARAM: Invalid parameter.";
+                break;
+            case LIBUSB_ERROR_ACCESS :
+                msg = "LIBUSB_ERROR_ACCESS: Access denied (insufficient permissions)";
+                break;
+            case LIBUSB_ERROR_NO_DEVICE :
+                msg = "LIBUSB_ERROR_NO_DEVICE: No such device (it may have been disconnected)";
+                break;
+            case LIBUSB_ERROR_NOT_FOUND :
+                msg = "LIBUSB_ERROR_NOT_FOUND: Entity not found.";
+                break;
+            case LIBUSB_ERROR_BUSY :
+                msg = "LIBUSB_ERROR_BUSY: Resource busy.";
+                break;
+            case LIBUSB_ERROR_TIMEOUT :
+                msg = "LIBUSB_ERROR_TIMEOUT: Operation timed out.";
+                break;
+            case LIBUSB_ERROR_OVERFLOW :
+                msg = "LIBUSB_ERROR_OVERFLOW: Overflow.";
+                break;
+            case LIBUSB_ERROR_PIPE :
+                msg = "LIBUSB_ERROR_PIPE: Pipe error.";
+                break;
+            case LIBUSB_ERROR_INTERRUPTED :
+                msg = "LIBUSB_ERROR_INTERRUPTED: System call interrupted (perhaps due to signal)";
+                break;
+            case LIBUSB_ERROR_NO_MEM :
+                msg = "LIBUSB_ERROR_NO_MEM: Insufficient memory.";
+                break;
+            case LIBUSB_ERROR_NOT_SUPPORTED :
+                msg = "LIBUSB_ERROR_NOT_SUPPORTED: Operation not supported or unimplemented on this platform.";
+                break;
+            case LIBUSB_ERROR_OTHER :
+                msg = "LIBUSB_ERROR_OTHER: Other error.";
+                break;
+#else   /* HAVE_LIBUSB_1_0 */
             case -ENOENT:
                 msg = "-ENOENT: URB was canceled by unlink_urb";
                 break;
@@ -810,7 +859,6 @@ static void dfu_msg_response_output( const char *function,
                 msg = "-EILSEQ: CRC mismatch";
                 break;
             case -EPIPE:
-                // think that in libusb, -9 is LIBUSB_ERROR_PIPE
                 msg = "-EPIPE: a) Babble detect or b) Endpoint stalled";
                 break;
 #ifdef ETIMEDOUT
@@ -836,12 +884,12 @@ static void dfu_msg_response_output( const char *function,
             case -EINVAL:
                 msg = "-EINVAL: ISO madness, if this happens: Log off and go home";
                 break;
+#endif  /* HAVE_LIBUSB_1_0 */
             default:
                 msg = "Unknown error";
                 break;
         }
-
-        DEBUG( "%s 0x%08x (%d)\n", msg, result, result );
+        DEBUG( "%s ERR: %s 0x%08x (%d)\n", function, msg, result, result );
     }
 }
 

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -83,6 +83,16 @@ typedef struct {
     uint8_t iString;
 } dfu_status_t;
 
+void dfu_set_transaction_num( uint16_t newnum );
+/* set / reset the wValue parameter to a given value. this number is
+ * significant for stm32 device commands (see dfu-device.h)
+ */
+
+uint16_t dfu_get_transaction_num( void );
+/* get the current transaction number (can be used to calculate address
+ * offset for stm32 devices --- see dfu-device.h)
+ */
+
 int32_t dfu_detach( dfu_device_t *device, const int32_t timeout );
 /*  DFU_DETACH Request (DFU Spec 1.0, Section 5.1)
  *

--- a/src/intel_hex.c
+++ b/src/intel_hex.c
@@ -51,10 +51,13 @@ struct intel_record {
 #define IHEX_64KB_PAGE 0x10000
 
 
-#define IHEX_DEBUG_THRESHOLD 50
+#define IHEX_DEBUG_THRESHOLD    50
+#define IHEX_TRACE_THRESHOLD    55
 
 #define DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
                                IHEX_DEBUG_THRESHOLD, __VA_ARGS__ )
+#define TRACE(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
+                               IHEX_TRACE_THRESHOLD, __VA_ARGS__ )
 
 // ________  P R O T O T Y P E S  _______________________________
 static int intel_validate_checksum( struct intel_record *record );
@@ -229,15 +232,17 @@ static void intel_invalid_addr_warning(uint32_t line_count, uint32_t address,
             " suppressing additional address error messages.\n" );
 }
 
-int32_t intel_process_data( atmel_buffer_out_t *bout, char value,
+int32_t intel_process_data( intel_buffer_out_t *bout, char value,
         uint32_t target_offset, uint32_t address) {
-    // NOTE : there are some hex program files that contain data in the user
-    // page, which is outside of 'valid' memory.  In this situation, the hex
-    // file is processed and used as normal with a warning message containing
-    // the first line with an invalid address.
+    /* NOTE : there are some hex program files that contain data in the user
+     * page, which is outside of 'valid' memory.  In this situation, the hex
+     * file is processed and used as normal with a warning message containing
+     * the first line with an invalid address.
+     */
     uint32_t raddress;   // relative address = address - target offset
 
-    // The Atmel flash page starts at address 0x80000000, we need to ignore
+    // The Atmel flash page starts at address 0x8000 0000, we need to ignore
+    //             stm32 flash page starts at 0x0800 0000
     // that bit
     target_offset &= 0x7fffffff;
     address &= 0x7fffffff;
@@ -263,8 +268,8 @@ int32_t intel_process_data( atmel_buffer_out_t *bout, char value,
     return 0;
 }
 
-int32_t intel_hex_to_buffer( char *filename, atmel_buffer_out_t *bout,
-        uint32_t target_offset, dfu_bool quiet ) {
+int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
+                             uint32_t target_offset, dfu_bool quiet ) {
     FILE *fp = NULL;
     struct intel_record record;
     // unsigned int count, type, checksum, address; char data[256]
@@ -347,9 +352,9 @@ int32_t intel_hex_to_buffer( char *filename, atmel_buffer_out_t *bout,
                                  (((uint32_t) record.data[1]) << 16) |
                                  (((uint32_t) record.data[2]) <<  8) |
                                   ((uint32_t) record.data[3]);
-                /* Note: In AVR32 memory map, FLASH starts at 0x80000000, but the
-                 * ISP places this memory at 0.  The hex file will use 0x8..., so
-                 * mask off that bit. */
+                /* Note: In AVR32 memory map, FLASH starts at 0x80000000, but
+                 * the ISP places this memory at 0. The hex file will use
+                 * 0x8..., so mask off that bit. */
                 address_offset = (0x7fffffff & address_offset);
                 DEBUG( "Address offset set to 0x%x.\n", address_offset );
                 break;
@@ -461,8 +466,8 @@ static int32_t ihex_make_record_04_offset( uint32_t offset, char *str ) {
 //    return 0;
 //}
 
-int32_t intel_hex_from_buffer( atmel_buffer_in_t *buin,
-        dfu_bool force_full, uint32_t target_offset ) {
+int32_t intel_hex_from_buffer( intel_buffer_in_t *buin,
+                               dfu_bool force_full, uint32_t target_offset ) {
     char line[80];
     uint32_t offset_address = 0;    // offset address written to a previous line
     uint32_t address = 0;   // relative offset from previously set addr
@@ -550,5 +555,141 @@ int32_t intel_hex_from_buffer( atmel_buffer_in_t *buin,
     }
     fprintf( stdout, ":00000001FF\n" );
 
+    return 0;
+}
+
+int32_t intel_init_buffer_out( intel_buffer_out_t *bout,
+                               size_t total_size, size_t page_size ) {
+    uint32_t i;
+    if ( !total_size || !page_size ) {
+        DEBUG("What are you thinking... size must be > 0.\n");
+        return -1;
+    }
+
+    bout->info.total_size = total_size;
+    bout->info.page_size = page_size;
+    bout->info.data_start = UINT32_MAX;      // invalid data start
+    bout->info.data_end = 0;
+    bout->info.valid_start = 0;
+    bout->info.valid_end = total_size - 1;
+    bout->info.block_start = 0;
+    bout->info.block_end = 0;
+    // allocate the memory
+    bout->data = (uint16_t *) malloc( total_size * sizeof(uint16_t) );
+    if( NULL == bout->data ) {
+        DEBUG( "ERROR allocating 0x%X bytes of memory.\n",
+                total_size * sizeof(uint16_t));
+        return -2;
+    }
+
+    // initialize buffer to 0xFFFF (invalid / unassigned data)
+    for( i = 0; i < total_size; i++ ) {
+        bout->data[i] = UINT16_MAX;
+    }
+    return 0;
+}
+
+int32_t intel_init_buffer_in( intel_buffer_in_t *buin,
+                              size_t total_size, size_t page_size ) {
+    // TODO : is there a way to combine this and above? maybe typecast to an
+    // in or out buffer from a char pointer?
+    buin->info.total_size = total_size;
+    buin->info.page_size = page_size;
+    buin->info.data_start = 0;
+    buin->info.data_end = total_size - 1;
+    buin->info.valid_start = 0;
+    buin->info.valid_end = total_size - 1;
+    buin->info.block_start = 0;
+    buin->info.block_end = 0;
+
+    buin->data = (uint8_t *) malloc( total_size );
+    if( NULL == buin->data ) {
+        DEBUG( "ERROR allocating 0x%X bytes of memory.\n", total_size );
+        return -2;
+    }
+
+    // initialize buffer to 0xFF (blank / unassigned data)
+    memset( buin->data, UINT8_MAX, total_size );
+
+    return 0;
+}
+
+int32_t intel_validate_buffer( intel_buffer_in_t *buin,
+                               intel_buffer_out_t *bout,
+                               dfu_bool quiet) {
+    int32_t i;
+    int32_t invalid_data_region = 0;
+    int32_t invalid_outside_data_region = 0;
+
+    DEBUG( "Validating image from byte 0x%X to 0x%X.\n",
+            bout->info.valid_start, bout->info.valid_end );
+
+    if( !quiet ) fprintf( stderr, "Validating...  " );
+    for( i = bout->info.valid_start; i <= bout->info.valid_end; i++ ) {
+        if(  bout->data[i] <= UINT8_MAX ) {
+            // Memory should have been programmed here
+            if( ((uint8_t) bout->data[i]) != buin->data[i] ) {
+                if ( !invalid_data_region ) {
+                    if( !quiet ) fprintf( stderr, "ERROR\n" );
+                    DEBUG( "Image did not validate at byte: 0x%X of 0x%X.\n", i,
+                            bout->info.valid_end - bout->info.valid_start + 1 );
+                    DEBUG( "Wanted 0x%02x but read 0x%02x.\n",
+                            0xff & bout->data[i], buin->data[i] );
+                    DEBUG( "suppressing additional warnings.\n");
+                }
+                invalid_data_region++;
+            }
+        } else {
+            // Memory should be blank here
+            if( 0xff != buin->data[i] ) {
+                if ( !invalid_data_region ) {
+                    DEBUG( "Outside program region: byte 0x%X epected 0xFF.\n", i);
+                    DEBUG( "but read 0x%02X.  supressing additional warnings.\n",
+                            buin->data[i] );
+                }
+                invalid_outside_data_region++;
+            }
+        }
+    }
+
+    if( !quiet ) {
+        if ( 0 == invalid_data_region + invalid_outside_data_region ) {
+            fprintf( stderr, "Success\n" );
+        } else {
+            fprintf( stderr,
+                    "%d invalid bytes in program region, %d outside region.\n",
+                    invalid_data_region, invalid_outside_data_region );
+        }
+    }
+
+    return invalid_data_region ?
+        -1 * invalid_data_region : invalid_outside_data_region;
+}
+
+int32_t intel_flash_prep_buffer( intel_buffer_out_t *bout ) {
+    uint16_t *page;
+    int32_t i;
+
+    TRACE( "%s( %p )\n", __FUNCTION__, bout );
+
+    // increment pointer by page_size * sizeof(int16) until page_start >= end
+    for( page = bout->data;
+            page < &bout->data[bout->info.valid_end];
+            page = &page[bout->info.page_size] ) {
+        // check if there is valid data on this page
+        for( i = 0; i < bout->info.page_size; i++ ) {
+            if( page[i] <= UINT8_MAX )
+                break;
+        }
+
+        if( bout->info.page_size != i ) {
+            /* There was valid data in the block & we need to make
+             * sure there is no unassigned data.  */
+            for( i = 0; i < bout->info.page_size; i++ ) {
+                if( page[i] > UINT8_MAX )
+                    page[i] = 0xff;         // 0xff is blank
+            }
+        }
+    }
     return 0;
 }

--- a/src/intel_hex.h
+++ b/src/intel_hex.h
@@ -22,10 +22,31 @@
 #define __INTEL_HEX_H__
 
 #include <stdint.h>
+#include "dfu-bool.h"
 
-#include "atmel.h"
+typedef struct {
+    size_t total_size;          // the total size of the buffer
+    size_t  page_size;          // the size of a flash page
+    uint32_t block_start;       // the start addr of a transfer
+    uint32_t block_end;         // the end addr of a transfer
+    uint32_t data_start;        // the first valid data addr
+    uint32_t data_end;          // the last valid data addr
+    uint32_t valid_start;       // the first valid memory addr
+    uint32_t valid_end;         // the last valid memory addr
+} intel_buffer_info_t;
 
-int32_t intel_process_data( atmel_buffer_out_t *bout,
+typedef struct {
+    intel_buffer_info_t info;
+    uint16_t *data;
+} intel_buffer_out_t;
+
+typedef struct {
+    intel_buffer_info_t info;
+    uint8_t *data;
+} intel_buffer_in_t;
+
+
+int32_t intel_process_data( intel_buffer_out_t *bout,
         char value, uint32_t target_offset, uint32_t address);
 /* process a data value by adding to the buffer at the appropriate address or if
  * the address is out of range do nothing and return -1. Also update the valid
@@ -36,7 +57,7 @@ int32_t intel_process_data( atmel_buffer_out_t *bout,
 // NOTE : intel_process_data should be moved to a different module dealing with
 // processing any data and putting it into a buffer
 
-int32_t intel_hex_to_buffer( char *filename, atmel_buffer_out_t *bout,
+int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
         uint32_t target_offset, dfu_bool quiet );
 /*  Used to read in a file in intel hex format and return a chunk of
  *  memory containing the memory image described in the file.
@@ -62,14 +83,48 @@ int32_t intel_hex_to_buffer( char *filename, atmel_buffer_out_t *bout,
  *          - = all sorts of error codes (eg, no data in flash memory, ...)
  *              if the hex file contains no valid data an error is NOT thrown
  *              but the presence of valid data can be checked using the
- *              data_start field in atmel_buffer_out_t
+ *              data_start field in intel_buffer_out_t
  */
 
-int32_t intel_hex_from_buffer( atmel_buffer_in_t *buin,
+int32_t intel_hex_from_buffer( intel_buffer_in_t *buin,
         dfu_bool force_full, uint32_t target_offset );
 /*  Used to convert a buffer to an intel hex formatted file.
  *  target offset is the address location of buffer 0
  *  force_full sets whether to keep writing entirely blank pages.
+ */
+
+int32_t intel_init_buffer_out(intel_buffer_out_t *bout,
+        size_t total_size, size_t page_size );
+/* initialize a buffer used to send data to flash memory
+ * the total size and page size must be provided.
+ * the data array is filled with 0xFFFF (an invalid memory
+ * value) indicating that it is unassigned. data start and
+ * data end are initialized with UINT32_MAX indicating there
+ * is no valid data in the buffer.  these two values are simply
+ * convenience values so the start and end of data do not need
+ * to be found multiple times.
+ */
+
+int32_t intel_init_buffer_in(intel_buffer_in_t *buin,
+        size_t total_size, size_t page_size );
+/* initialize a buffer_in, used for reading the contents of program
+ * memory.  total memory size must be provided.  the data array is filled
+ * with 0xFF, which is unprogrammed memory.
+ */
+
+int32_t intel_validate_buffer(  intel_buffer_in_t *buin,
+                                intel_buffer_out_t *bout, dfu_bool quiet);
+/* compare the contents of buffer_in with buffer_out to check that a target
+ * memory image matches with a memory read.
+ * return 0 for full validation, positive number if data bytes outside region do
+ * not validate, negative number if bytes inside region that do not validate
+ */
+
+int32_t intel_flash_prep_buffer( intel_buffer_out_t *bout );
+/* prepare the buffer so that valid data fills each page that contains data.
+ * unassigned data in buffer is given a value of 0xff (blank memory)
+ * the buffer pointer must align with the beginning of a flash page
+ * return 0 on success, -1 if assigning data would extend flash above size
  */
 
 #endif

--- a/src/stm32.c
+++ b/src/stm32.c
@@ -1,0 +1,788 @@
+/** dfu-programmer
+  *
+  * This program is free software; you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation; either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program; if not, write to the Free Software Foundation,
+  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+  */
+
+//___ I N C L U D E S ________________________________________________________
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <string.h>
+#include <stddef.h>
+#include <errno.h>
+
+#include "dfu-bool.h"
+#include "dfu-device.h"
+#include "config.h"
+#include "arguments.h"
+#include "dfu.h"
+#include "stm32.h"
+#include "util.h"
+
+
+//___ M A C R O S   ( P R I V A T E ) ________________________________________
+#define STM32_DEBUG_THRESHOLD   50
+#define STM32_TRACE_THRESHOLD   55
+
+#define DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, STM32_DEBUG_THRESHOLD, __VA_ARGS__ )
+#define TRACE(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, STM32_TRACE_THRESHOLD, __VA_ARGS__ )
+
+#define STM32_MAX_TRANSFER_SIZE     0x0800  /* 2048 */
+#define STM32_MIN_SECTOR_BOUND      0x4000  /* 16 kb */
+#define STM32_OTP_BYTES_SIZE        528     /* number of OTP bytes (0x210) */
+#define STM32_OPTION_BYTES_SIZE     16      /* number option bytes */
+
+#define SET_ADDR_PTR            0x21
+#define ERASE_CMD               0x41
+#define READ_UNPROTECT          0x92
+#define GET_CMD                 0x00
+
+//___ T Y P E D E F S   ( P R I V A T E ) ____________________________________
+
+//___ P R O T O T Y P E S   ( P R I V A T E ) ________________________________
+static inline int32_t stm32_get_status( dfu_device_t *device );
+  /* run dfu_get_status to get the current status
+   * retrn  0 on status OK, -1 on status req fail, -2 on bad status
+   */
+
+static int32_t stm32_set_address_ptr( dfu_device_t *device, uint32_t address );
+  /* @brief set the address pointer to a certain address
+   * @param the address to set
+   * @retrn 0 on success, negative on failure
+   */
+
+static int32_t stm32_write_block( dfu_device_t *device,
+                                  size_t xfer_len,
+                                  uint8_t *buffer );
+  /* flash the contents of memory into a block of memory.  it is assumed that
+   * the appropriate page has already been selected.  start and end are the
+   * start and end addresses of the flash data.  returns 0 on success,
+   * positive dfu error code if one is obtained, or negative if communitcation
+   * with device fails.
+   */
+
+static int32_t stm32_read_block( dfu_device_t *device,
+                                   size_t xfer_len,
+                                   uint8_t *buffer );
+  /* read a block of memory, assumes address pointer is already set
+   */
+
+static inline void print_progress( intel_buffer_info_t *info,
+                    uint32_t *progress );
+  /* calculate how many progress indicator steps to print and print them
+   * update progress value
+   */
+
+
+//___ V A R I A B L E S ______________________________________________________
+extern int debug;
+
+/* FIXME : these should be read from usb device descriptor because they are
+ * device specififc */
+static const uint32_t stm32_sector_addresses[] = {
+  0x08000000,   /* sector  0,  16 kb */
+  0x08004000,   /* sector  1,  16 kb */
+  0x08008000,   /* sector  2,  16 kb */
+  0x0800C000,   /* sector  3,  16 kb */
+  0x08010000,   /* sector  4,  64 kb */
+  0x08020000,   /* sector  5, 128 kb */
+  0x08040000,   /* sector  6, 128 kb */
+  0x08060000,   /* sector  7, 128 kb */
+  0x08080000,   /* sector  8, 128 kb */
+  0x080A0000,   /* sector  9, 128 kb */
+  0x080C0000,   /* sector 10, 128 kb */
+  0x080E0000,   /* sector 11, 128 kb */
+  0x1FFF0000,   /* system memory, 30 kb */
+  0x1FFF7800,   /* OTP area, 528 bytes */
+  0x1FFFC000,   /* Option bytes, 16 bytes */
+};
+
+//___ F U N C T I O N S   ( P R I V A T E ) __________________________________
+static inline int32_t stm32_get_status( dfu_device_t *device ) {
+  dfu_status_t status;
+  if( 0 == dfu_get_status(device, &status) ) {
+    if( status.bStatus == DFU_STATUS_OK ) {
+      DEBUG( "Status OK\n" );
+    } else {
+      DEBUG( "Status %s not OK, use DFU_CLRSTATUS\n",
+          dfu_status_to_string(status.bStatus) );
+      dfu_clear_status( device );
+      return -2;
+    }
+  } else {
+    DEBUG( "DFU_GETSTATUS request failed\n" );
+    return -1;
+  }
+
+  return 0;
+}
+
+static int32_t stm32_set_address_ptr( dfu_device_t *device, uint32_t address ) {
+  TRACE( "%s( 0x%X )\n", __FUNCTION__, address );
+  const uint8_t length = 5;
+  int32_t status;
+
+  uint8_t command[] = {
+    (uint8_t) SET_ADDR_PTR,
+    (uint8_t) address & 0xFF,           /* address LSB */
+    (uint8_t) (address>>8) & 0xFF,
+    (uint8_t) (address>>16) & 0xFF,
+    (uint8_t) (address>>24) & 0xFF      /* address MSB */
+  };
+
+  /* check dfu status for okay to send */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d getting status on start\n", status);
+    return -1;
+  }
+
+  dfu_set_transaction_num( 0 );     /* set wValue to zero */
+  if( length != dfu_download(device, length, command) ) {
+    DEBUG( "dfu_download failed\n" );
+    return -2;
+  }
+
+  /* call dfu get status to trigger command */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
+    return -3;
+  }
+
+  /* check command success */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d: %s unsuccessful\n", status, __FUNCTION__);
+    return -4;
+  }
+
+  return 0;
+}
+
+static int32_t stm32_write_block( dfu_device_t *device,
+                                  size_t xfer_len,
+                                  uint8_t *buffer ) {
+  TRACE( "%s( %p, %u, %p )\n", __FUNCTION__, device, xfer_len, buffer );
+  int32_t status;
+
+  /* check input args */
+  if( (NULL == device) || (NULL == buffer) ) {
+    DEBUG( "ERROR: Invalid arguments, device/buffer pointer is NULL.\n" );
+    return -1;
+  } else if ( xfer_len > STM32_MAX_TRANSFER_SIZE ) {
+    DEBUG( "ERROR: 0x%X byte message > MAX TRANSFER SIZE (0x%X).\n",
+        xfer_len, STM32_MAX_TRANSFER_SIZE );
+    return -1;
+  } else if ( xfer_len < 1 ) {
+    DEBUG( "ERROR: xfer_len is %u\n", xfer_len );
+    return -1;
+  }
+
+  if( xfer_len != dfu_download(device, xfer_len, buffer) ) {
+    DEBUG( "dfu_download failed\n" );
+    return -3;
+  }
+
+  /* call dfu get status to trigger command */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
+    return -3;
+  }
+
+  /* check that the command was successfully executed */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d: %s unsuccessful\n", status, __FUNCTION__);
+    return -4;
+  }
+
+  return 0;
+}
+
+static int32_t stm32_read_block( dfu_device_t *device,
+                                   size_t xfer_len,
+                                   uint8_t *buffer ) {
+  TRACE( "%s( %p, %u, %p )\n", __FUNCTION__, device, xfer_len, buffer );
+  int32_t result;
+
+  if( buffer == NULL ) {
+    DEBUG("ERROR: buffer ptr is NULL\n");
+    return -1;
+  } else if( xfer_len > STM32_MAX_TRANSFER_SIZE ) {
+    /* this could cause a read problem */
+    DEBUG("ERROR: transfer size %d exceeds max %d.\n",
+        xfer_len, STM32_MAX_TRANSFER_SIZE );
+    return -1;
+  }
+
+  /* check status before read */
+  if( (result = stm32_get_status(device)) ) {
+    DEBUG("Status Error %d before read\n", result );
+    return -2;
+  }
+
+  result = dfu_upload( device, xfer_len, buffer );
+  if( result < 0) {
+    dfu_status_t status;
+
+    DEBUG( "ERROR: dfu_upload result: %d\n", result );
+    if( 0 == dfu_get_status(device, &status) ) {
+      DEBUG( "Error Status %s, state %s\n",
+          dfu_status_to_string(status.bStatus),
+          dfu_state_to_string(status.bState) );
+      if( status.bStatus == DFU_STATUS_ERROR_VENDOR ) {
+        /* status = dfuERROR and state = errVENDOR */
+        DEBUG("Device is read protected\n");
+        return STM32_READ_PROT_ERROR;
+      }
+    } else {
+      DEBUG("DFU GET_STATUS fail\n");
+    }
+    dfu_clear_status( device );
+
+    return result;
+  }
+
+  return 0;
+}
+
+static inline void print_progress( intel_buffer_info_t *info,
+                                     uint32_t *progress ) {
+  if ( !(debug > STM32_DEBUG_THRESHOLD) ) {
+    while ( ((info->block_end - info->data_start + 1) * 32) > *progress ) {
+      fprintf( stderr, ">" );
+      *progress += info->data_end - info->data_start + 1;
+    }
+  }
+}
+
+
+//___ F U N C T I O N S ______________________________________________________
+int32_t stm32_erase_flash( dfu_device_t *device, dfu_bool quiet ) {
+  TRACE( "%s( %p, %s )\n", __FUNCTION__, device, quiet ? "ture" : "false" );
+  uint8_t command[] = { ERASE_CMD };
+  uint8_t length = 1;
+  int32_t status;
+
+  if( !quiet ) {
+    fprintf( stderr, "Erasing flash...  " );
+    DEBUG("\n");
+  }
+
+  dfu_set_transaction_num( 0 );     /* set wValue to zero */
+  if( length != dfu_download(device, length, command) ) {
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    DEBUG( "dfu_download failed\n" );
+    return -3;
+  }
+
+  /* call dfu get status to trigger command */
+  if( (status = stm32_get_status(device)) ) {
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
+    return -3;
+  }
+
+  /* It can take a while to erase the chip so 10 seconds before giving up */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d: %s unsuccessful\n", status, __FUNCTION__);
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    return -4;
+  } else {
+    if( !quiet ) fprintf( stderr, "DONE\n" );
+  }
+
+  return 0;
+}
+
+int32_t stm32_page_erase( dfu_device_t *device, uint32_t address,
+                           dfu_bool quiet ) {
+  TRACE( "%s( %p, 0x%X, %s )\n", __FUNCTION__, device, address,
+      quiet ? "ture" : "false" );
+  uint8_t length = 5;
+  int32_t status;
+
+  uint8_t command[5] = {
+    ERASE_CMD,
+    (uint8_t) (0xff & address),             //  page LSB
+    (uint8_t) (0xff & ((address)>>8)),
+    (uint8_t) (0xff & ((address)>>16)),
+    (uint8_t) (0xff & ((address)>>24))      // page MSB
+  };
+
+  dfu_set_transaction_num( 0 );     /* set wValue to zero */
+  if( length != dfu_download(device, length, command) ) {
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    DEBUG( "dfu_download failed\n" );
+    return -3;
+  }
+
+  /* call dfu get status to trigger command */
+  if( (status = stm32_get_status(device)) ) {
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
+    return -3;
+  }
+
+  /* It can take a while to erase the chip so 10 seconds before giving up */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d: %s unsuccessful\n", status, __FUNCTION__);
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    return -4;
+  } else {
+    if( !quiet ) fprintf( stderr, "DONE\n" );
+  }
+
+  return 0;
+}
+
+int32_t stm32_start_app( dfu_device_t *device, dfu_bool quiet ) {
+  TRACE( "%s( %p )\n", __FUNCTION__, device );
+  int32_t status;
+
+  /* set address pointer (jump target) to start address */
+  if( (status = stm32_set_address_ptr( device, STM32_FLASH_OFFSET )) ) {
+    DEBUG("Error setting address pointer\n");
+    return -1;
+  }
+
+  /* check dfu status for ok to send */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d getting status on start\n", status);
+    return -1;
+  }
+
+  if( !quiet ) fprintf( stderr, "Launching program...  \n" );
+  dfu_set_transaction_num( 0 );     /* set wValue to zero */
+  if( 0 != dfu_download(device, 0, NULL) ) {
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    DEBUG( "dfu_download failed\n" );
+    return -3;
+  }
+
+  /* call dfu get status to trigger command */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
+    return -3;
+  }
+
+  return 0;
+}
+
+int32_t stm32_read_flash( dfu_device_t *device, intel_buffer_in_t *buin,
+    const uint8_t mem_segment, const dfu_bool quiet ) {
+  TRACE( "%s( %p, %p, %u, %s )\n", __FUNCTION__, device, buin,
+      mem_segment, ((true == quiet) ? "true" : "false"));
+
+  uint8_t  reset_address_flag;  // reset address offset required
+  uint32_t address_offset;  // keep record of sent progress as bytes * 32
+  uint16_t  xfer_size = 0;      // the size of a transfer
+  uint8_t mem_section = 0;       // tracks the current memory page
+  uint32_t progress = 0;      // used to indicate progress
+  int32_t status;
+  int32_t retval = -1;      // the return value for this function
+
+  if( (NULL == buin) || (NULL == device) ) {
+    DEBUG( "invalid arguments.\n" );
+    if( !quiet )
+      fprintf( stderr, "Program Error, use debug for more info.\n" );
+    return -1;
+  }
+
+  if( !quiet ) {
+    if( debug <= STM32_DEBUG_THRESHOLD ) {
+      /* NOTE: From here on we should go to finally on error */
+      fprintf( stderr, "[================================] " );
+    }
+    fprintf( stderr, "Reading 0x%X bytes...\n",
+        buin->info.data_end - buin->info.data_start + 1 );
+    if( debug <= STM32_DEBUG_THRESHOLD ) {
+      /* NOTE: From here on we should go to finally on error */
+      fprintf( stderr, "[" );
+    }
+  }
+
+  /* read the data */
+  buin->info.block_start = buin->info.data_start;
+  reset_address_flag = 0;
+  address_offset = buin->info.block_start;
+
+  while( buin->info.block_start <= buin->info.data_end ) {
+    if( reset_address_flag ) {
+      address_offset = buin->info.block_start;
+      if( (status = stm32_set_address_ptr(device,
+              STM32_FLASH_OFFSET + address_offset)) ) {
+        DEBUG("Error setting address 0x%X\n", address_offset);
+        retval = -3;
+        goto finally;
+      }
+      dfu_set_transaction_num( 2 ); /* sets block offset 0 */
+      reset_address_flag = 0;
+    }
+
+    // find end value for the current transfer
+    buin->info.block_end = buin->info.block_start + STM32_MAX_TRANSFER_SIZE - 1;
+    mem_section = buin->info.block_start / STM32_MIN_SECTOR_BOUND;
+    if( buin->info.block_end / STM32_MIN_SECTOR_BOUND > mem_section ) {
+      buin->info.block_end = STM32_MIN_SECTOR_BOUND * mem_section - 1;
+    }
+    if( buin->info.block_end > buin->info.data_end ) {
+      buin->info.block_end = buin->info.data_end;
+    }
+    xfer_size = buin->info.block_end - buin->info.block_start + 1;
+    if( xfer_size != STM32_MAX_TRANSFER_SIZE ) {
+      DEBUG("xfer_size change, need addr reset\n");
+      reset_address_flag = 1;
+    }
+
+    if( (status = stm32_read_block( device, xfer_size,
+            &buin->data[buin->info.block_start] )) ) {
+      DEBUG( "Error reading block 0x%X to 0x%X: err %d.\n",
+          buin->info.block_start, buin->info.block_end, status );
+      retval = ( status == -10 ) ? -10 : -5;
+      /* read protect error code in read_block is -10 */
+      goto finally;
+    }
+
+    buin->info.block_start = buin->info.block_end + 1;
+    if( reset_address_flag == 0 && (buin->info.block_start !=
+        (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num() - 2))
+        + address_offset) ) {
+      DEBUG("block start & address mismatch, reset req\n");
+      reset_address_flag = 1;
+    }
+
+    if( !quiet ) print_progress( &buin->info, &progress );
+  }
+  retval = 0;
+
+finally:
+  if ( !quiet ) {
+    if( 0 == retval ) {
+      if ( debug <= STM32_DEBUG_THRESHOLD ) {
+        fprintf( stderr, "] " );
+      }
+      fprintf( stderr, "SUCCESS\n" );
+    } else {
+      if ( debug <= STM32_DEBUG_THRESHOLD ) {
+        fprintf( stderr, " X  ");
+      }
+      fprintf( stderr, "ERROR\n" );
+      if( retval==-3 )
+        fprintf( stderr,
+            "Memory access error, use debug for more info.\n" );
+      else if( retval==-5 )
+        fprintf( stderr,
+            "Memory read error, use debug for more info.\n" );
+    }
+  }
+  return retval;
+}
+
+int32_t stm32_write_flash( dfu_device_t *device, intel_buffer_out_t *bout,
+    const dfu_bool eeprom, const dfu_bool force, const dfu_bool quiet ) {
+  TRACE( "%s( %p, %p, %s, %s )\n", __FUNCTION__, device, bout,
+          ((true == eeprom) ? "true" : "false"),
+          ((true == quiet) ? "true" : "false") );
+
+  uint32_t i;
+  uint32_t progress = 0;    // keep record of sent progress as bytes * 32
+  uint32_t address_offset;  // keep record of sent progress as bytes * 32
+  uint8_t  reset_address_flag;  // reset address offset required
+  uint16_t  xfer_size = 0;      // the size of a transfer
+  uint8_t mem_section = 0;   // tracks the current memory page
+  int32_t retval = -1;  // the return value for this function
+  uint8_t buffer[STM32_MAX_TRANSFER_SIZE];     // buffer holding out data
+  int32_t status;
+
+  /* check arguments */
+  if( (NULL == device) || (NULL == bout) ) {
+    DEBUG( "ERROR: Invalid arguments, device/buffer pointer is NULL.\n" );
+    if( !quiet )
+      fprintf( stderr, "Program Error, use debug for more info.\n" );
+    return -1;
+  } else if( bout->info.valid_start > bout->info.valid_end ) {
+    DEBUG( "ERROR: No valid target memory, end 0x%X before start 0x%X.\n",
+        bout->info.valid_end, bout->info.valid_start );
+    if( !quiet )
+      fprintf( stderr, "Program Error, use debug for more info.\n" );
+    return -1;
+  }
+
+  /* for each page with data, fill unassigned values on the page with 0xFF
+   * bout->data[0] always aligns with a flash page boundary irrespective
+   * of where valid_start is located */
+  if( 0 != intel_flash_prep_buffer( bout ) ) {
+    if( !quiet )
+      fprintf( stderr, "Program Error, use debug for more info.\n" );
+    return -2;
+  }
+
+  /* determine the limits of where actual data resides in the buffer */
+  bout->info.data_start = UINT32_MAX;
+  for( i = 0; i < bout->info.total_size; i++ ) {
+    if( bout->data[i] <= UINT8_MAX ) {
+      bout->info.data_end = i;
+      if( bout->info.data_start == UINT32_MAX )
+        bout->info.data_start = i;
+    }
+  }
+
+  /* debug info about data limits */
+  DEBUG("Flash available from 0x%X to 0x%X, 0x%X bytes.\n",
+      bout->info.valid_start, bout->info.valid_end,
+      bout->info.valid_end - bout->info.valid_start + 1); // bytes inclusive so +1
+  DEBUG("Data start @ 0x%X; %uB p 0x%X + 0x%X offset.\n",
+      bout->info.data_start, bout->info.page_size,
+      bout->info.data_start / bout->info.page_size,
+      bout->info.data_start % bout->info.page_size);
+  DEBUG("Data end @ 0x%X; %uB p 0x%X + 0x%X offset.\n",
+      bout->info.data_end, bout->info.page_size,
+      bout->info.data_end / bout->info.page_size,
+      bout->info.data_end % bout->info.page_size);
+  DEBUG("Totals: 0x%X bytes, %u %uB pages.\n",
+      bout->info.data_end - bout->info.data_start + 1,
+      bout->info.data_end / bout->info.page_size \
+        - bout->info.data_start/bout->info.page_size + 1,
+      bout->info.page_size );
+
+  /* more error checking */
+  if( (bout->info.data_start < bout->info.valid_start) ||
+      (bout->info.data_end > bout->info.valid_end) ) {
+    DEBUG( "ERROR: Data exists outside of the valid target flash region.\n" );
+    if( !quiet )
+      fprintf( stderr, "Hex file error, use debug for more info.\n" );
+    return -1;
+  } else if( bout->info.data_start == UINT32_MAX ) {
+    DEBUG( "ERROR: No valid data to flash.\n" );
+    if( !quiet )
+      fprintf( stderr, "Hex file error, use debug for more info.\n" );
+    return -1;
+  }
+
+  if( !quiet ) {
+    if( debug <= STM32_DEBUG_THRESHOLD ) {
+      /* NOTE: from here on we should run finally block */
+      fprintf( stderr, "[================================] " );
+    }
+    fprintf( stderr, "Programming 0x%X bytes...\n",
+        bout->info.data_end - bout->info.data_start + 1 );
+    if( debug <= STM32_DEBUG_THRESHOLD ) {
+      /* NOTE: from here on we need to run finally block */
+      fprintf( stderr, "[" );
+    }
+  }
+
+  /* program the data */
+  bout->info.block_start = bout->info.data_start;
+  reset_address_flag = 1;
+
+  while( bout->info.block_start <= bout->info.data_end ) {
+    if( reset_address_flag ) {
+      address_offset = bout->info.block_start;
+      if( (status = stm32_set_address_ptr(device,
+              STM32_FLASH_OFFSET + address_offset)) ) {
+        DEBUG("Error setting address 0x%X\n", address_offset);
+        retval = -3;
+        goto finally;
+      }
+      dfu_set_transaction_num( 2 ); /* sets block offset 0 */
+      reset_address_flag = 0;
+    }
+
+    /* find end address (info.block_end) for data section to write */
+    mem_section = bout->info.block_start / STM32_MIN_SECTOR_BOUND;
+    for( i = 0, bout->info.block_end = bout->info.block_start;
+         bout->info.block_end <= bout->info.data_end;
+         bout->info.block_end++, i++ ) {
+      xfer_size = bout->info.block_end - bout->info.block_start + 1;
+      // check if the current value is valid
+      if( bout->data[bout->info.block_end] > UINT8_MAX ) break;
+      // check if the current data packet is too big
+      if( xfer_size > STM32_MAX_TRANSFER_SIZE ) break;
+      // check if the current data value is outside of the memory sector
+      if( bout->info.block_end / STM32_MIN_SECTOR_BOUND - mem_section ) break;
+
+      buffer[i] = (uint8_t) bout->data[bout->info.block_end];
+    }
+    bout->info.block_end--; // bout->info.block_end was one step beyond the last data value to flash
+    xfer_size = bout->info.block_end - bout->info.block_start + 1;
+    if( xfer_size != STM32_MAX_TRANSFER_SIZE ) {
+      DEBUG("xfer_size %u not max %u, need addr reset\n",
+          xfer_size, STM32_MAX_TRANSFER_SIZE);
+      reset_address_flag = 1;
+    }
+
+    /* write the data */
+    DEBUG("Program data block: 0x%X to 0x%X, 0x%X bytes.\n",
+        bout->info.block_start, bout->info.block_end, xfer_size);
+
+    if( (status = stm32_write_block( device, xfer_size, buffer )) ) {
+      DEBUG( "Error flashing the block: err %d.\n", status );
+      retval = -4;
+      goto finally;
+    }
+
+    // incrment bout->info.block_start to the next valid address
+    for( bout->info.block_start = bout->info.block_end + 1;
+         bout->info.block_start <= bout->info.data_end;
+         bout->info.block_start++ ) {
+      if( (bout->data[bout->info.block_start] <= UINT8_MAX) ) break;
+    } // bout->info.block_start is now on the first valid data for the next segment
+
+    if( reset_address_flag == 0 && (bout->info.block_start !=
+        (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num() - 2))
+        + address_offset) ) {
+      DEBUG("block start does not match addr, reset req\n");
+      reset_address_flag = 1;
+    }
+
+    // display progress in 32 increments (if not hidden)
+    if ( !quiet ) print_progress( &bout->info, &progress );
+  }
+  retval = 0;
+
+finally:
+  if ( !quiet ) {
+    if( 0 == retval ) {
+      if ( debug <= STM32_DEBUG_THRESHOLD ) {
+        fprintf( stderr, "] " );
+      }
+      fprintf( stderr, "SUCCESS\n" );
+    } else {
+      if ( debug <= STM32_DEBUG_THRESHOLD ) {
+        fprintf( stderr, " X  ");
+      }
+      fprintf( stderr, "ERROR\n" );
+      if( retval==-3 )
+        fprintf( stderr,
+            "Memory access error, use debug for more info.\n" );
+      else if( retval==-4 )
+        fprintf( stderr,
+            "Memory write error, use debug for more info.\n" );
+    }
+  }
+
+  return retval;
+}
+
+int32_t stm32_get_commands( dfu_device_t *device ) {
+  TRACE("%s( %p )\n", __FUNCTION__, device);
+  int32_t result;
+  uint8_t i;
+  const size_t xfer_len = 80;
+  uint8_t buffer[xfer_len];
+
+  /* check status before read */
+  if( (result = stm32_get_status(device)) ) {
+    DEBUG("Status Error %d before read\n", result );
+    return -2;
+  }
+
+  dfu_set_transaction_num( 0 );
+  result = dfu_upload( device, xfer_len, buffer );
+  if( result < 0) {
+    dfu_status_t status;
+
+    DEBUG( "dfu_upload result: %d\n", result );
+    if( 0 == dfu_get_status(device, &status) ) {
+      if( status.bStatus == DFU_STATUS_OK ) {
+        DEBUG("DFU Status OK, state %d\n", status.bState);
+      } else if( status.bStatus == DFU_STATUS_ERROR_VENDOR ) {
+        DEBUG("Device is read protected\n");
+        /* status = dfuERROR and state = errVENDOR */
+      } else {
+        DEBUG("Unknown error status %d / state %d\n",
+            status.bStatus, status.bState );
+      }
+    } else {
+      DEBUG("DFU GET_STATUS fail\n");
+    }
+    dfu_clear_status( device );
+
+    return result;
+  }
+
+  fprintf( stdout, "There are %d commands:\n", result );
+  for( i = 0; i < result; i++ ) {
+    fprintf( stdout, "  0x%02X\n", buffer[i] );
+  }
+
+  return 0;
+}
+
+int32_t stm32_get_configuration( dfu_device_t *device ) {
+  TRACE("%s( %p )\n", __FUNCTION__, device);
+  int32_t status;
+  uint8_t i;
+  uint8_t buffer[STM32_OPTION_BYTES_SIZE];
+
+  if( (status = stm32_set_address_ptr(device,
+          stm32_sector_addresses[mem_st_option_bytes])) ) {
+    DEBUG("Error (%d) setting address 0x%X\n",
+        status, stm32_sector_addresses[mem_st_option_bytes]);
+    return -1;
+  }
+
+  if( (status = stm32_read_block(device, STM32_OPTION_BYTES_SIZE, buffer)) ) {
+    DEBUG("Error (%d) reading option buffer block\n", status );
+    return -2;
+  }
+
+  fprintf( stdout, "There are %d option bytes:\n", STM32_OPTION_BYTES_SIZE );
+  fprintf( stdout, "0x%02X", buffer[0] );
+  for( i = 1; i < STM32_OPTION_BYTES_SIZE; i++ ) {
+    fprintf( stdout, ", 0x%02X", buffer[i] );
+  }
+  fprintf( stdout, "\n" );
+
+  return 0;
+}
+
+int32_t stm32_read_unprotect( dfu_device_t *device, dfu_bool quiet ) {
+  TRACE("%s( %p )\n", __FUNCTION__, device);
+  uint8_t command[] = { READ_UNPROTECT };
+  uint8_t length = 1;
+  int32_t status;
+
+  if( !quiet ) {
+    fprintf( stderr, "Read Unprotect, Erasing flash...  " );
+    DEBUG("\n");
+  }
+
+  dfu_set_transaction_num( 0 );     /* set wValue to zero */
+  if( length != dfu_download(device, length, command) ) {
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    DEBUG( "dfu_download failed\n" );
+    return -3;
+  }
+
+  /* call dfu get status to trigger command */
+  if( (status = stm32_get_status(device)) ) {
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
+    return -3;
+  }
+
+  /* It can take a while to erase the chip so 10 seconds before giving up */
+  if( (status = stm32_get_status(device)) ) {
+    DEBUG("Error %d: %s unsuccessful\n", status, __FUNCTION__);
+    if( !quiet ) fprintf( stderr, "ERROR\n" );
+    return -4;
+  } else {
+    if( !quiet ) fprintf( stderr, "DONE\n" );
+  }
+
+  return 0;
+}
+
+// vim: shiftwidth=2

--- a/src/stm32.h
+++ b/src/stm32.h
@@ -1,0 +1,137 @@
+/** dfu-programmer
+  *
+  * This program is free software; you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation; either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program; if not, write to the Free Software
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+  */
+
+#ifndef __STM32_H__
+#define __STM32_H__
+
+#include <stdio.h>
+#include <stdint.h>
+#include "dfu-bool.h"
+#include "dfu-device.h"
+#include "intel_hex.h"
+
+#define STM32_FLASH_OFFSET 0x08000000
+
+typedef enum {
+  mem_st_sector0 = 0,
+  mem_st_sector1,
+  mem_st_sector2,
+  mem_st_sector3,
+  mem_st_sector4,
+  mem_st_sector5,
+  mem_st_sector6,
+  mem_st_sector7,
+  mem_st_sector8,
+  mem_st_sector9,
+  mem_st_sector10,
+  mem_st_sector11,
+  mem_st_system,
+  mem_st_otp_area,
+  mem_st_option_bytes,
+  mem_st_all,
+} stm32_mem_sectors;
+
+
+#define STM32_MEM_UNIT_NAMES "Sector 0", "Sector 1", "Sector 2", "Sector 3", \
+  "Sector 4", "Sector 5", "Sector 6", "Sector 7", "Sector 8", "Sector 9", \
+  "Sector 10", "Sector 11", "System Memory", "OTP Area", "Option Bytes", "all"
+
+#define STM32_READ_PROT_ERROR   -10
+
+
+int32_t stm32_erase_flash( dfu_device_t *device, dfu_bool quiet );
+  /*  mass erase flash
+   *  device  - the usb_dev_handle to communicate with
+   *  returns status DFU_STATUS_OK if ok, anything else on error
+   */
+
+int32_t stm32_page_erase( dfu_device_t *device, uint32_t address,
+    dfu_bool quiet );
+  /* erase a page of memory (provide the page address) */
+
+int32_t stm32_start_app( dfu_device_t *device, dfu_bool quiet );
+  /* Reset the registers to default reset values and start application
+   */
+
+int32_t stm32_read_flash( dfu_device_t *device,
+              intel_buffer_in_t *buin,
+              uint8_t mem_segment,
+              const dfu_bool quiet);
+  /* read the flash from buin->info.data_start to data_end and place
+   * in buin.data. mem_segment is the segment of memory from the
+   * stm32_memory_unit_enum.
+   */
+
+int32_t stm32_write_flash( dfu_device_t *device, intel_buffer_out_t *bout,
+    const dfu_bool eeprom, const dfu_bool force, const dfu_bool hide_progress );
+  /* Flash data from the buffer to the main program memory on the device.
+   * buffer contains the data to flash where buffer[0] is aligned with memory
+   * address zero (which could be inside the bootloader and unavailable).
+   * buffer[start / end] correspond to the start / end of available memory
+   * outside the bootloader.
+   * flash_page_size is the size of flash pages - used for alignment
+   * eeprom bool tells if you want to flash to eeprom or flash memory
+   * hide_progress bool sets whether to display progress
+   */
+
+int32_t stm32_get_commands( dfu_device_t *device );
+  /* @brief get the commands list, should be length 4
+   * @param device pointer
+   * @retrn 0 on success
+   */
+
+int32_t stm32_get_configuration( dfu_device_t *device );
+  /* @brief get the configuration structure
+   * @param device pointer
+   * @retrn 0 on success, negative for error
+   */
+
+int32_t stm32_read_unprotect( dfu_device_t *device, dfu_bool quiet );
+  /* @brief unprotect the device (triggers a mass erase)
+   * @param device pointer
+   * @retrn 0 on success
+   */
+
+
+
+#if 0
+int32_t stm32_read_config( dfu_device_t *device,
+               stm32_device_info_t *info );
+
+int32_t stm32_read_fuses( dfu_device_t *device, stm32_avr32_fuses_t * info );
+
+int32_t stm32_set_fuse( dfu_device_t *device, const uint8_t property,
+    const uint32_t value );
+
+int32_t stm32_set_config( dfu_device_t *device, const uint8_t property,
+    const uint8_t value );
+
+int32_t stm32_blank_check( dfu_device_t *device, const uint32_t start,
+    const uint32_t end, dfu_bool quiet );
+
+int32_t stm32_secure( dfu_device_t *device );
+
+int32_t stm32_getsecure( dfu_device_t *device );
+
+int32_t stm32_user( dfu_device_t *device, intel_buffer_out_t *bout );
+
+void stm32_print_device_info( FILE *stream, stm32_device_info_t *info );
+#endif
+
+#endif  /* __STM32_H__ */
+
+// vim: shiftwidth=2

--- a/src/util.c
+++ b/src/util.c
@@ -23,7 +23,7 @@
 
 #include "util.h"
 
-extern int debug;
+extern int debug;       /* defined in main.c */
 
 void dfu_debug( const char *file, const char *function, const int line,
                 const int level, const char *format, ... )


### PR DESCRIPTION
There are two primary commits here, the first moves general buffer related operations out of atmel.c and into intel_hex.c, and the second implements another dfu-programmer command set related to stm32 devices.  I'm asking for a merge here because there are many shared tools (such as intel parsing, validation, buffer mgmt, usb dfu, etc) that are important for any dfu-programmer, not just atmel's.  