### PR TITLE
Fix erase exiting with non-zero value when success.

### DIFF
--- a/src/atmel.c
+++ b/src/atmel.c
@@ -898,6 +898,9 @@ static int32_t __atmel_blank_page_check( dfu_device_t *device,
     if( DFU_STATUS_OK == status.bStatus ) {
         DEBUG( "Flash region from 0x%X to 0x%X is blank.\n", start, end );
     } else if ( DFU_STATUS_ERROR_CHECK_ERASED == status.bStatus ) {
+        if ( STATE_DFU_ERROR == status.bState ) {
+            dfu_clear_status( device );
+        }
         // need to DFU upload to get the address
         DEBUG( "Region is NOT bank.\n" );
         uint8_t addr[2] = { 0x00, 0x00 };


### PR DESCRIPTION
```atmel_erase_flash``` uses ```status.bStatus``` as return value when success at [line 495](https://github.com/dfu-programmer/dfu-programmer/blob/master/src/atmel.c#L495).
Before there, ```execute_erase``` from commands.c calls ```atmel_blank_check``` first, within it, ```__atmel_blank_page_check``` will be called.
The problem is, when page is not blank, program will go into [this block](https://github.com/dfu-programmer/dfu-programmer/blob/master/src/atmel.c#L901-L912) and return.
Without a ```dfu_clear_status``` here, status in the device will keep as below.
```
dfu.c:230: ==============================
dfu.c:232: status->bStatus: errCHECK_ERASED (0x05)
dfu.c:233: status->bwPollTimeout: 0x0000 ms
dfu.c:235: status->bState: dfuERROR (0x0a)
dfu.c:236: status->iString: 0x00
dfu.c:237: ------------------------------
```
Finally, ```atmel_erase_flash``` will return ```errCHECK_ERASED (0x05)``` even it has successed.

I think my minor change can fix this problem but I'm not sure is it the proper solution.
Please give me some advice.