### PR TITLE
Replaced fprintf placeholder with the correct one

### DIFF
--- a/src/intel_hex.c
+++ b/src/intel_hex.c
@@ -376,7 +376,7 @@ error:
     }
 
     if( retval & !quiet ) {
-        fprintf( stderr, "See --debug=%u or greater for more information.\n",
+        fprintf( stderr, "See --debug=%d or greater for more information.\n",
                 IHEX_DEBUG_THRESHOLD + 1 );
     }
 


### PR DESCRIPTION
cppcheck shows that `IHEX_DEBUG_THRESHOLD + 1` is a signed int so the fprintf placeholder can be replaced with the proper one.