### PR TITLE
Add '--validate-first' and '--ignore-outside' options to the flash command

### DIFF
--- a/dfu_completion
+++ b/dfu_completion
@@ -70,7 +70,7 @@ _dfu-programmer () {
         ;;
       flash)
         filetype="hex"
-        flags="--force --user --eeprom --bin --suppress-validation --suppress-bootloader-mem --serial="
+        flags="--force --user --eeprom --bin --suppress-validation --suppress-bootloader-mem --validate-first --ignore-outside --serial="
         eeprom_size=$( echo $TARGET_INFO | sed "s/.* $target:://" | sed 's/ .*//' )
         if [[ "$eeprom_size" == 0 ]]; then
           flags=$( echo $flags | sed 's/--eeprom//' )

--- a/docs/dfu-programmer.1
+++ b/docs/dfu-programmer.1
@@ -114,6 +114,8 @@ Erase first checks if the memory is blank unless \-\-force flag is set.
 [(flash)|\-\-user|\-\-eeprom]
 [\-\-suppress\-validation]
 [\-\-suppress\-bootloader\-mem]
+[\-\-validate\-first]
+[\-\-ignore\-outside]
 [\-\-serial=hexbytes:offset]
 file or STDIN
 .br
@@ -141,6 +143,16 @@ on. There must be an even number of hex digits, but the sequence can
 be any length. The offset is assumed to be given in hex if it starts
 with a "0x" prefix, octal if it begins with a "0", otherwise is it
 assumed to be decimal.
+.PP
+\-\-validate\-first add a validate before writing the flash memory. If the
+validate succeeds (i.e. the firmware in the chip is the same as the one
+given as input), then no further operations are done, and the flash is
+reported as successfull.
+.PP
+\-\-ignore\-outside changes the validate behavior to ignore any error
+outside the programming region. This can be useful for programming a single
+part of the chip (where errors outside region are expected) without ignoring
+the validate result.
 .HP
 .B setsecure
 .br

--- a/docs/dfu-programmer.html
+++ b/docs/dfu-programmer.html
@@ -140,7 +140,8 @@ chip erase must be performed before other commands become available.
 Erase first checks if the memory is blank unless --force flag is set.
 </p>
 <h4><b>flash</b> [--force] [(flash)|--user|--eeprom] [--suppress-validation] 
-[--suppress-bootloader-mem]<br /> [--serial=hexbytes:offset] file or STDIN</h4>
+[--suppress-bootloader-mem] [--validate-first] [--ignore-outside]<br />
+[--serial=hexbytes:offset] file or STDIN</h4>
 <p>
 Writes flash memory.  The input file (or stdin) must use the "ihex" file
 format convention for a memory image. --suppress-bootloader-mem
@@ -167,6 +168,18 @@ on. There must be an even number of hex digits, but the sequence can
 be any length. The offset is assumed to be given in hex if it starts
 with a "0x" prefix, octal if it begins with a "0", otherwise is it
 assumed to be decimal.
+</p>
+<p>
+--validate-first add a validate before writing the flash memory. If the
+validate succeeds (i.e. the firmware in the chip is the same as the one
+given as input), then no further operations are done, and the flash is
+reported as successfull.
+</p>
+<p>
+--ignore-outside changes the validate behavior to ignore any error
+outside the programming region. This can be useful for programming a
+single part of the chip (where errors outside region are expected) without
+ignoring the validate result.
 </p>
 <h4><b>setsecure</b></h4>
 <p>

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -358,6 +358,8 @@ static void usage()
     fprintf( stderr, "        flash        [--force] [(flash)|--user|--eeprom]\n"
                      "                     [--suppress-validation]\n"
                      "                     [--suppress-bootloader-mem]\n"
+                     "                     [--validate-first]\n"
+                     "                     [--ignore-outside]\n"
                      "                     [--serial=hexdigits:offset] {file|STDIN}\n" );
     fprintf( stderr, "        setsecure\n" );
     fprintf( stderr, "        configure {BSB|SBV|SSB|EB|HSB}"
@@ -568,6 +570,46 @@ static int32_t assign_global_options( struct programmer_arguments *args,
                 case com_eflash:
                 case com_user:
                     args->com_flash_data.suppress_validation = 1;
+                    break;
+                default:
+                    /* not supported. */
+                    return -1;
+            }
+            break;
+        }
+    }
+
+    /* Find '--validate-first' if it is here - even though it is not
+     * used by all this is easier. */
+    for( i = 0; i < argc; i++ ) {
+        if( 0 == strcmp("--validate-first", argv[i]) ) {
+            *argv[i] = '\0';
+
+            switch( args->command ) {
+                case com_flash:
+                case com_eflash:
+                case com_user:
+                    args->com_flash_data.validate_first = 1;
+                    break;
+                default:
+                    /* not supported. */
+                    return -1;
+            }
+            break;
+        }
+    }
+
+    /* Find '--ignore-outside' if it is here - even though it is not
+     * used by all this is easier. */
+    for( i = 0; i < argc; i++ ) {
+        if( 0 == strcmp("--ignore-outside", argv[i]) ) {
+            *argv[i] = '\0';
+
+            switch( args->command ) {
+                case com_flash:
+                case com_eflash:
+                case com_user:
+                    args->com_flash_data.ignore_outside = 1;
                     break;
                 default:
                     /* not supported. */

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -218,6 +218,8 @@ struct programmer_arguments {
                                      is on last one or two words in the user
                                      page depending on the version of the
                                      bootloader - force overwrite required */
+            dfu_bool validate_first; /* Do a validate before flashing */
+            dfu_bool ignore_outside; /* Ignore validate errors outside region */
             enum atmel_memory_unit_enum segment;
         } com_flash_data;
 

--- a/src/atmel.c
+++ b/src/atmel.c
@@ -197,7 +197,7 @@ static int32_t atmel_read_command( dfu_device_t *device,
 
 static inline void __print_progress( intel_buffer_info_t *info,
                                         uint32_t *progress ) {
-    if ( !(debug > ATMEL_DEBUG_THRESHOLD) ) {
+    if ( !(debug > ATMEL_DEBUG_THRESHOLD) && isatty(2) ) {
         while ( ((info->block_end - info->data_start + 1) * 32) > *progress ) {
             fprintf( stderr, PROGRESS_BAR );
             *progress += info->data_end - info->data_start + 1;
@@ -663,13 +663,13 @@ int32_t atmel_read_flash( dfu_device_t *device,
     }
 
     if( !quiet ) {
-        if( debug <= ATMEL_DEBUG_THRESHOLD ) {
+        if( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
             // NOTE: From here on we should go to finally on error
             fprintf( stderr, PROGRESS_METER );
         }
         fprintf( stderr, "Reading 0x%X bytes...\n",
                 buin->info.data_end - buin->info.data_start + 1 );
-        if( debug <= ATMEL_DEBUG_THRESHOLD ) {
+        if( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
             // NOTE: From here on we should go to finally on error
             fprintf( stderr, PROGRESS_START );
         }
@@ -723,12 +723,12 @@ int32_t atmel_read_flash( dfu_device_t *device,
 finally:
     if ( !quiet ) {
         if( 0 == retval ) {
-            if ( debug <= ATMEL_DEBUG_THRESHOLD ) {
+            if ( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
                 fprintf( stderr, PROGRESS_END );
             }
             fprintf( stderr, "Success\n" );
         } else {
-            if ( debug <= ATMEL_DEBUG_THRESHOLD ) {
+            if ( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
                 fprintf( stderr, PROGRESS_ERROR );
             }
             fprintf( stderr, "ERROR\n" );
@@ -1237,13 +1237,13 @@ int32_t atmel_flash( dfu_device_t *device,
     }
 
     if( !quiet ) {
-        if( debug <= ATMEL_DEBUG_THRESHOLD ) {
+        if( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
             // NOTE: from here on we need to run finally block
             fprintf( stderr, PROGRESS_METER );
         }
         fprintf( stderr, "Programming 0x%X bytes...\n",
                 bout->info.data_end - bout->info.data_start + 1 );
-        if( debug <= ATMEL_DEBUG_THRESHOLD ) {
+        if( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
             // NOTE: from here on we need to run finally block
             fprintf( stderr, PROGRESS_START );
         }
@@ -1309,12 +1309,12 @@ int32_t atmel_flash( dfu_device_t *device,
 finally:
     if ( !quiet ) {
         if( 0 == retval ) {
-            if ( debug <= ATMEL_DEBUG_THRESHOLD ) {
+            if ( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
                 fprintf( stderr, PROGRESS_END );
             }
             fprintf( stderr, "Success\n" );
         } else {
-            if ( debug <= ATMEL_DEBUG_THRESHOLD ) {
+            if ( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
                 fprintf( stderr, PROGRESS_ERROR );
             }
             fprintf( stderr, "ERROR\n" );


### PR DESCRIPTION
These options allow proper programming of atxmega devices with locked Application_Table sections (and probably other devices where a partial programming is done).

The `'--validate-first'` option avoid a check before calling the flash command, and will transform the flash command into a no-op if the embedded firmware is already the proper one.

The `'--ignore-outside'` option will tweak the `execute_validate(...)` function to return `SUCCESS` when `VALIDATION_ERROR_OUTSIDE_REGION` would have been returned without it.

The `atom.mk` file is here to allow building the program with [Alchemy](https://github.com/Parrot-Developers/alchemy), and should require no further maintenance (it only instructs alchemy to call the bootstrap.sh script and the build the program using the autotools.

Auto-completion and documentation are updated according to the changes.
