### PR TITLE
Fix device specification, publish with GitHub actions, and build for libusb1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+AUTHORS text
+ChangeLog text
+COPYING text
+NEWS text
+README text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,251 @@
+name: Build dfu-programmer
+
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  Windows-x32-libusb0:
+    name: Windows x86 with libusb0
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: C:/msys64/usr/bin/bash.exe --noprofile --norc -e -x -o pipefail {0}
+
+    env:
+      AM_COLOR_TESTS: always
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Dependencies
+        run: |
+          # Fix issues with MSYS2 and cygwin tools conflicting by just using MSYS2
+          export PATH=/usr/bin:/usr/local/bin
+
+          # While some of these are already available, they are cygwin versions which are incompatible with MSYS2
+          pacman --color always --noconfirm -S automake-wrapper autoconf-wrapper make mingw-w64-i686-gcc
+
+      - name: Bootstrap
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw32/bin
+          ./bootstrap.sh
+
+          # Per README instructions
+          cp windows/usb.h    /mingw32/include/
+          cp windows/libusb.a /mingw32/lib/
+
+      - name: Override Version
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        id: override
+        shell: bash
+        run: echo ::set-output 'name=override::PACKAGE_STRING="dfu-programmer ${{ github.ref_name }} ${{ github.sha }}"'
+
+      - name: Configure
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw32/bin
+          ./configure --disable-dependency-tracking --disable-libusb_1_0 ${{ steps.override.outputs.override }}
+
+      - name: Build
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw32/bin
+          make -j4
+
+      - name: Download Atmel FLIP
+        uses: suisei-cn/actions-download-file@v1.0.1
+        id: flip
+        with:
+          url: https://ww1.microchip.com/downloads/en/DeviceDoc/Flip%20Installer%20-%203.4.7.112.exe
+
+      - name: Extract Atmel FLIP
+        run: 7z x ${{ steps.flip.outputs.filename }} usb COPYING_GPL.txt
+        shell: pwsh
+
+      - name: Prep dist
+        shell: pwsh
+        run: |
+          mkdir dist
+
+          # Don't forget the license
+          mv COPYING_GPL.txt usb/
+
+          # Not sure where this version number comes from
+          mv usb dist/dfu-prog-usb-1.2.2
+          # mv usb dist/
+
+          # The binary
+          cp src/dfu-programmer.exe dist/
+
+          # The docs
+          cp docs/dfu-programmer.html dist/
+
+      - name: Upload dist as Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: Windows x86 - libusb0 - dfu-programmer
+          path: dist
+
+      - name: Get version
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: version
+        shell: bash
+        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+
+      - name: Make release archives of binaries
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: pwsh
+        working-directory: dist
+        run: |
+          7z a -tzip ../dfu-programmer-win-${{ steps.version.outputs.version }}.zip *
+          7z a -t7z  ../dfu-programmer-win-${{ steps.version.outputs.version }}.7z  *
+
+      - name: Test
+        shell: pwsh
+        run: |
+          mv dist/dfu-prog-usb-1.2.2/x86/libusb0_x86.dll dist/libusb0.dll
+          dist/dfu-programmer.exe --help
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            dfu-programmer-win-${{ steps.version.outputs.version }}.zip
+            dfu-programmer-win-${{ steps.version.outputs.version }}.7z
+
+  Linux:
+    name: Linux x64 with libusb1
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: sudo apt-get install -y libusb-dev
+
+      - uses: actions/checkout@v3
+
+      - name: bootstrap
+        run: ./bootstrap.sh
+
+      - name: Override Version
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        id: override
+        run: echo ::set-output 'name=override::PACKAGE_STRING="dfu-programmer ${{ github.ref_name }} ${{ github.sha }}"'
+
+      - name: configure
+        run: ./configure --disable-dependency-tracking ${{ steps.override.outputs.override }}
+
+      - name: make
+        run: make -j4
+
+      - name: Test
+        run: src/dfu-programmer --help
+
+      - name: Upload Binary as Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: Linux x64 - libusb1 - dfu-programmer binary
+          path: src/dfu-programmer
+
+      - name: make dist
+        run: make -j4 dist
+
+      - name: Get version and Changes
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: version
+        run: |
+          echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+
+          echo "## Changes" > CHANGES
+          echo "" >> CHANGES
+          sed -ne '2,/^== Release/p' NEWS | head -n -2 >> CHANGES
+
+      - name: Upload Tarball as Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: Linux x64 - libusb1 - dfu-programmer dist
+          path: "*.tar.gz"
+
+      - name: Make release archives of binaries
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: src
+        run: |
+          7z a -tzip ../dfu-programmer-linux-${{ steps.version.outputs.version }}.zip dfu-programmer
+          7z a -t7z  ../dfu-programmer-linux-${{ steps.version.outputs.version }}.7z  dfu-programmer
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          body_path: CHANGES
+          fail_on_unmatched_files: true
+          files: |
+            dfu-programmer-${{ steps.version.outputs.version }}.tar.gz
+            dfu-programmer-linux-${{ steps.version.outputs.version }}.zip
+            dfu-programmer-linux-${{ steps.version.outputs.version }}.7z
+
+  macOS:
+    name: macOS x64 with libusb1
+    runs-on: macos-latest
+
+    steps:
+      - run: brew install automake
+
+      - uses: actions/checkout@v3
+
+      - name: bootstrap
+        run: ./bootstrap.sh
+
+      - name: Override Version
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        id: override
+        run: echo ::set-output 'name=override::PACKAGE_STRING="dfu-programmer ${{ github.ref_name }} ${{ github.sha }}"'
+
+      - name: configure
+        run: ./configure --disable-dependency-tracking ${{ steps.override.outputs.override }}
+
+      - name: make
+        run: make -j4
+
+      - name: Test
+        run: src/dfu-programmer --help
+
+      - name: Upload Binary as Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: macOS - libusb1 - dfu-programmer binary
+          path: src/dfu-programmer
+
+      - name: make dist
+        run: make -j4 dist
+
+      - name: Upload Tarball as Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: macOS - libusb1 - dfu-programmer dist
+          path: "*.tar.gz"
+
+      - name: Get version
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+
+      - name: Make release archives of binaries
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: src
+        run: |
+          7z a -tzip ../dfu-programmer-macOS-${{ steps.version.outputs.version }}.zip dfu-programmer
+          7z a -t7z  ../dfu-programmer-macOS-${{ steps.version.outputs.version }}.7z  dfu-programmer
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            dfu-programmer-macOS-${{ steps.version.outputs.version }}.zip
+            dfu-programmer-macOS-${{ steps.version.outputs.version }}.7z

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,182 @@ jobs:
             dfu-programmer-win-${{ steps.version.outputs.version }}.zip
             dfu-programmer-win-${{ steps.version.outputs.version }}.7z
 
+  Windows-x32-libusb1:
+    name: Windows x86 with libusb1
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: C:/msys64/usr/bin/bash.exe --noprofile --norc -e -x -o pipefail {0}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Dependencies
+        run: |
+          # Fix issues with MSYS2 and cygwin tools conflicting by just using MSYS2
+          export PATH=/usr/bin:/usr/local/bin
+
+          # While some of these are already available, they are cygwin versions which are incompatible with MSYS2
+          pacman --color always --noconfirm -S automake-wrapper autoconf-wrapper make mingw-w64-i686-gcc mingw-w64-i686-libusb
+
+      - name: Bootstrap
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw32/bin
+          ./bootstrap.sh
+
+      - name: Override Version
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        id: override
+        shell: bash
+        run: echo ::set-output 'name=override::PACKAGE_STRING="dfu-programmer ${{ github.ref_name }} ${{ github.sha }}"'
+
+      - name: Configure
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw32/bin
+          ./configure --disable-dependency-tracking ${{ steps.override.outputs.override }}
+
+      - name: Build
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw32/bin
+          make -j4
+
+      - name: Prep dist
+        shell: pwsh
+        run: |
+          mkdir dist
+
+          # The binary
+          cp src/dfu-programmer.exe dist/
+
+          # The docs
+          cp docs/dfu-programmer.html dist/
+
+          # Libusb 1.0
+          cp C:/msys64/mingw32/bin/libusb-1.0.dll dist/
+          cp C:/msys64/mingw32/share/licenses     dist/ -Recurse
+
+      - name: Upload dist as Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: Windows x86 - libusb1 - dfu-programmer
+          path: dist
+
+      - name: Test
+        shell: pwsh
+        run: dist/dfu-programmer.exe --help
+
+      - name: Get version
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: version
+        shell: bash
+        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+
+      - name: Make release archives of binaries
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: pwsh
+        working-directory: dist
+        run: |
+          7z a -tzip ../dfu-programmer-win32-libusb1-${{ steps.version.outputs.version }}.zip *
+          7z a -t7z  ../dfu-programmer-win32-libusb1-${{ steps.version.outputs.version }}.7z  *
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            dfu-programmer-win32-libusb1-${{ steps.version.outputs.version }}.zip
+            dfu-programmer-win32-libusb1-${{ steps.version.outputs.version }}.7z
+
+  Windows-x64-libusb1:
+    name: Windows x64 with libusb1
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: C:/msys64/usr/bin/bash.exe --noprofile --norc -e -x -o pipefail {0}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Dependencies
+        run: |
+          # Fix issues with MSYS2 and cygwin tools conflicting by just using MSYS2
+          export PATH=/usr/bin:/usr/local/bin
+
+          # While some of these are already available, they are cygwin versions which are incompatible with MSYS2
+          pacman --color always --noconfirm -S automake-wrapper autoconf-wrapper make mingw-w64-x86_64-gcc mingw-w64-x86_64-libusb
+
+      - name: Bootstrap
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw64/bin
+          ./bootstrap.sh
+
+      - name: Override Version
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        id: override
+        shell: bash
+        run: echo ::set-output 'name=override::PACKAGE_STRING="dfu-programmer ${{ github.ref_name }} ${{ github.sha }}"'
+
+      - name: Configure
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw64/bin
+          ./configure --disable-dependency-tracking ${{ steps.override.outputs.override }}
+
+      - name: Build
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:/mingw64/bin
+          make -j4
+
+      - name: Prep dist
+        shell: pwsh
+        run: |
+          mkdir dist
+
+          # The binary
+          cp src/dfu-programmer.exe dist/
+
+          # The docs
+          cp docs/dfu-programmer.html dist/
+
+          # Libusb 1.0
+          cp C:/msys64/mingw64/bin/libusb-1.0.dll dist/
+          cp C:/msys64/mingw64/share/licenses     dist/ -Recurse
+
+      - name: Upload dist as Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: Windows x64 - libusb1 - dfu-programmer
+          path: dist
+
+      - name: Test
+        shell: pwsh
+        run: dist/dfu-programmer.exe --help
+
+      - name: Get version
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: version
+        shell: bash
+        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+
+      - name: Make release archives of binaries
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: pwsh
+        working-directory: dist
+        run: |
+          7z a -tzip ../dfu-programmer-win64-libusb1-${{ steps.version.outputs.version }}.zip *
+          7z a -t7z  ../dfu-programmer-win64-libusb1-${{ steps.version.outputs.version }}.7z  *
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            dfu-programmer-win64-libusb1-${{ steps.version.outputs.version }}.zip
+            dfu-programmer-win64-libusb1-${{ steps.version.outputs.version }}.7z
+
   Linux:
     name: Linux x64 with libusb1
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ src/*.hex
 
 # tab completion file
 dfu_programmer
+
+m4/
+
+*~

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,11 @@
+{
+	"configurations": [
+		{
+			"name": "gcc",
+			"defines": ["__VSCODE__", "HAVE_CONFIG_H"],
+			"includePath": ["src"],
+			"compilerPath": "gcc"
+		}
+	],
+	"version": 4
+}

--- a/AUTHORS
+++ b/AUTHORS
@@ -95,3 +95,4 @@ Contributors:
         - Fix infinite loop using rpl_malloc
     - Cameron Tacklind
         - GitHub Actions Configuration
+        - Build libusb1 versions for Windows

--- a/AUTHORS
+++ b/AUTHORS
@@ -93,3 +93,5 @@ Contributors:
         - Fix exit status of help-related options and improve start sequence
     - Alban Bedel
         - Fix infinite loop using rpl_malloc
+    - Cameron Tacklind
+        - GitHub Actions Configuration

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,0 @@
-This file is no longer maintained. You can find a summary of changes in
-the NEWS file. For a detailed view of the changes go to the online
-source repository at GitHub and browse the commit history.

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+== Release 0.8.0 [2016-01-19]
+ * Experimental support for ST cortex M4
+
 == Release 0.7.2 [2015-02-04]
  * Fix memory bounds used for XMega targets.
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 == Release 0.8.1 [2022-10-13]
  * Fix bug preventing specifying a device with libusb0
  * Fix bug in order device id was printed with libusb0
+ * Publish Windows binaries with libusb1
+ * Update libusb1 include path
+ * Update uses of deprecated libusb1 functions
 
 == Release 0.8.0 [2016-01-19]
  * Experimental support for ST cortex M4

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+== Release 0.8.1 [2022-10-13]
+ * Fix bug preventing specifying a device with libusb0
+ * Fix bug in order device id was printed with libusb0
+
 == Release 0.8.0 [2016-01-19]
  * Experimental support for ST cortex M4
  * Enable GitHub Actions for releases [2022-10-13]

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 == Release 0.8.0 [2016-01-19]
  * Experimental support for ST cortex M4
+ * Enable GitHub Actions for releases [2022-10-13]
+ * Make `./bootstrap.sh` fail if any command fails (and print commands)
+ * Update `configure.ac` features
+ * Added IntelliSense hints for Visual Studio Code
 
 == Release 0.7.2 [2015-02-04]
  * Fix memory bounds used for XMega targets.

--- a/README
+++ b/README
@@ -84,17 +84,20 @@ Simple install procedure for Unix/Linux/MAC
 Build procedure for Windows
 ===========================
 
-  Building Windows apps from source is never quite as simple ...
-  Firstly you need to have MinGW and MSys with developer tools.
-  Get them from http://sourceforge.net/projects/mingw/files/.
-  See `.github/workflows/build.yml` for examples of building on Windows
-  and the needed tools.
+Building Windows apps from source is never quite as simple ...
+Firstly you need to have MinGW and MSys with developer tools.
+Get them from http://sourceforge.net/projects/mingw/files/.
+See `.github/workflows/build.yml` for examples of building on Windows
+and the needed tools.
 
-  Open the MinGW shell window and change to the dfu-programmer folder.
-  Note that C:\dir is accessed in MinGW using the path /c/dir
+Open the MinGW shell window and change to the dfu-programmer folder.
+Note that C:\dir is accessed in MinGW using the path /c/dir
 
   [ If the source was checked-out from GitHub, run the following command ]
   $ ./bootstrap.sh
+
+  libusb0
+  -------
 
   The Windows build uses the libusb-win32 library, which is a
   port of libusb 0.1. For convenience these files are included
@@ -107,6 +110,19 @@ Build procedure for Windows
 
   $ ./configure --disable-libusb_1_0
 
+  libusb1
+  -------
+
+  The Windows build also supports libusb-1.0. If you install with
+  the pacman package `mingw-w64-i686-libusb` or `mingw-w64-x86_64-libusb`,
+  for the 32-bit or 64-bit builds respectively, include and lib files
+  will be installed in the correct locations.
+
+  $ ./configure
+
+  build
+  -----
+
   $ make
 
   The executable will be built in the dfu-programmer/src folder.
@@ -115,7 +131,26 @@ Build procedure for Windows
 Windows Driver Files
 ====================
 
+  Atmel FLIP
+  ----------
+
   Atmel's FLIP programmer also uses libusb-win32, so we use the same
   library here and take advantage of Atmel's official certified driver
   set. The windows driver files can be downloaded as a separate zip file
   dfu-prog-usb-x.x.x.zip
+
+  Zadig
+  -----
+
+  Zadig is another popular tool for managing the current USB driver for
+  devices on your system. It can be used to install the libusb-win32 driver
+  or other popular drivers, including the official WinUSB driver. The
+  libusb-win32 driver has the broadest compatibility with builds of 
+  dfu-programmer, but that is not relevant on libusb1 builds of dfu-programmer.
+
+  | Zadig Driver | libusb0 x86 | libusb1 x86 | libusb1 x64 |
+  | ------------ | ----------- | ----------- | ----------- |
+  | WinUSB       | "no device" | Works       | Works       |
+  | libusb-win32 | Works       | Works       | Works       |
+  | libusbK      | "no device" | Works       | Works       |
+  | CDC          | "no device" | "no device" | "no device" |

--- a/README
+++ b/README
@@ -86,9 +86,17 @@ Build procedure for Windows
 
   Building Windows apps from source is never quite as simple ...
   Firstly you need to have MinGW and MSys with developer tools.
-  Get them from http://sourceforge.net/projects/mingw/files/
+  Get them from http://sourceforge.net/projects/mingw/files/.
+  See `.github/workflows/build.yml` for examples of building on Windows
+  and the needed tools.
 
-  The windows build uses the libusb-win32 library, which is a
+  Open the MinGW shell window and change to the dfu-programmer folder.
+  Note that C:\dir is accessed in MinGW using the path /c/dir
+
+  [ If the source was checked-out from GitHub, run the following command ]
+  $ ./bootstrap.sh
+
+  The Windows build uses the libusb-win32 library, which is a
   port of libusb 0.1. For convenience these files are included
   with this distribution, located in the windows sub-directory.
   You need to copy these files to your MinGW install directory
@@ -96,12 +104,6 @@ Build procedure for Windows
 
     windows/usb.h -> {path-to-mingw}/include/usb.h
     windows/libusb.a -> {path-to-mingw}/lib/libusb.a
-
-  Open the MinGW shell window and change to the dfu-programmer folder.
-  Note that C:\dir is accessed in MinGW using the path /c/dir
-
-  [ If the source was checked-out from GitHub, run the following command ]
-  $ ./bootstrap.sh
 
   $ ./configure --disable-libusb_1_0
 
@@ -112,7 +114,8 @@ Build procedure for Windows
 
 Windows Driver Files
 ====================
-Atmel's FLIP programmer also uses libusb-win32, so we use the same
-library here and take advantage of Atmel's official certified driver
-set. The windows driver files can be downloaded as a separate zip file
-dfu-prog-usb-x.x.x.zip
+
+  Atmel's FLIP programmer also uses libusb-win32, so we use the same
+  library here and take advantage of Atmel's official certified driver
+  set. The windows driver files can be downloaded as a separate zip file
+  dfu-prog-usb-x.x.x.zip

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,8 +1,14 @@
 #! /bin/sh
+
+set -e # exit on error
+set -x # Enable echoing of commands
+
 aclocal -I m4
 autoheader
 automake --foreign --add-missing --copy
 autoconf
+
+set +x # Disable echoing of commands
 
 if [ "$(echo `uname`)" = "Linux" ]; then
     TARGET_START_LINE=$( grep START_TARGET_LIST_LINE -n src/arguments.c  | \

--- a/configure.ac
+++ b/configure.ac
@@ -27,11 +27,9 @@ if test "$disable_libusb_1_0" = "no"; then
   ifdef([PKG_CHECK_MODULES],
         [PKG_CHECK_MODULES(LIBUSB_1_0, [ libusb-1.0 >= 1.0.0 ], have_libusb_1_0=yes, have_libusb_1_0=no)],
         [have_libusb_1_0=yes
-  LIBUSB_1_0_CFLAGS='-I${includedir}/libusb-1.0 -I${oldincludedir}/libusb-1.0'
   LIBUSB_1_0_LIBS=-lusb-1.0])
   if test "$have_libusb_1_0" = "yes"; then
     AS_ECHO("using libusb_1.0");
-    CFLAGS="$CFLAGS $LIBUSB_1_0_CFLAGS"
     LIBS="$LIBS $LIBUSB_1_0_LIBS"
     HAVE_USB=yes
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([dfu-programmer],[0.7.2],[],[],[https://github.com/dfu-programmer/dfu-programmer])
+AC_INIT([dfu-programmer],[0.8.0],[],[],[https://github.com/dfu-programmer/dfu-programmer])
 AC_CONFIG_AUX_DIR(m4)
 AC_CONFIG_SRCDIR([src/atmel.c])
 AM_INIT_AUTOMAKE

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_INIT([dfu-programmer],[0.8.0],[],[],[https://github.com/dfu-programmer/dfu-pr
 AC_CONFIG_AUX_DIR(m4)
 AC_CONFIG_SRCDIR([src/atmel.c])
 AM_INIT_AUTOMAKE
-AM_CONFIG_HEADER([src/config.h])
+AC_CONFIG_HEADERS([src/config.h])
 
 AM_MAINTAINER_MODE
 
@@ -18,7 +18,7 @@ AC_PROG_CC
 dnl Enable libusb-1.0, if available
 disable_libusb_1_0=no
 AC_ARG_ENABLE(libusb_1_0,
-    AC_HELP_STRING([--disable-libusb_1_0], [disable libusb-1.0 support even if available]),
+    AS_HELP_STRING([--disable-libusb_1_0],[disable libusb-1.0 support even if available]),
     [ if test "x$enableval" = "xno"; then disable_libusb_1_0=yes; fi ], [])
 
 dnl If libusb-1.0 is enabled and available, prefer that to the old libusb
@@ -37,7 +37,8 @@ if test "$disable_libusb_1_0" = "no"; then
   fi
 fi
 
-if test "$have_libusb_1_0" = "no"; then
+AS_IF([test "$have_libusb_1_0" = "no"],
+[
   dnl Fallback to the old libusb
   dnl libusb >= 0.1.8 is required, as we need usb_interrupt_read()
   AS_ECHO("using libusb");
@@ -45,7 +46,7 @@ if test "$have_libusb_1_0" = "no"; then
                   AC_CHECK_LIB(usb, usb_interrupt_read,
                                [LIBS="$LIBS -lusb"
                                 HAVE_USB=yes]))
-fi
+])
 
 dnl The following logic is useful for distributions.  If they force
 dnl USB support with --enable-libusb=yes then configure will fail
@@ -63,9 +64,8 @@ if test "$HAVE_USB" = "yes"; then
   fi
 fi
 
-
 # Checks for header files.
-AC_HEADER_STDC
+AC_CHECK_HEADERS([stddef.h stdint.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([dfu-programmer],[0.8.0],[],[],[https://github.com/dfu-programmer/dfu-programmer])
+AC_INIT([dfu-programmer],[0.8.1],[],[],[https://github.com/dfu-programmer/dfu-programmer])
 AC_CONFIG_AUX_DIR(m4)
 AC_CONFIG_SRCDIR([src/atmel.c])
 AM_INIT_AUTOMAKE

--- a/release_proc.txt
+++ b/release_proc.txt
@@ -12,7 +12,11 @@ Update info files
   Note that the list of devices shown in README and the docs can be auto-generated
   using dfu-programmer --targets / --targets-tex / --targets-html
 
-  Update the version number in configure.ac and push changes to GitHub.
+  Update the version number in configure.ac and push a tag with the format `vX.Y.Z` to GitHub.
+
+  Actions on GitHub will automatically build the release binaries and tarballs and publish them.
+
+  If you make a mistake in the automated release, simply force push a the tag to point to the new version.
 
 
 To create the source tarball
@@ -61,5 +65,5 @@ Upload
 Web page update
 ===============
 
-  Edit the index.php page in the dfu-programmer.github.io repository. As soon as the changes
+  Update the dfu-programmer.github.io repository. As soon as the changes
   are pushed back to the repo the web page will update.

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -432,9 +432,9 @@ static int32_t assign_target( struct programmer_arguments *args,
               int address = 0;
               if( 2 != sscanf(&value[name_len+1], "%i,%i", &bus, &address) )
                 return -1;
-              if (bus <= 0) return -1;
-              if (address <= 0) return -1;
-              args->bus_id = bus;
+              if (bus < 0) return -1;
+              if (address < 0) return -1;
+              args->bus_id = bus + 1;
               args->device_address = address;
             }
             args->device_type = map->device_type;

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -159,7 +159,7 @@ struct programmer_arguments {
     enum targets_enum target;
     uint16_t vendor_id;
     uint16_t chip_id;
-    uint16_t bus_id;            /* if non-zero, use bus_id and device_address */
+    uint16_t bus_id;            /* if non-zero, use bus_id-1 and device_address */
     uint16_t device_address;    /* to identify the specific target device.    */
     atmel_device_class_t device_type;
     char device_type_string[DEVICE_TYPE_STRING_MAX_LENGTH];

--- a/src/dfu-device.h
+++ b/src/dfu-device.h
@@ -6,7 +6,7 @@
 #endif
 #include <stdint.h>
 #ifdef HAVE_LIBUSB_1_0
-#include <libusb.h>
+#include <libusb-1.0/libusb.h>
 #else
 #include <usb.h>
 #endif

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -349,7 +349,7 @@ retry:
         if( (vendor  == descriptor.idVendor) &&
             (product == descriptor.idProduct) &&
             ((bus_number == 0)
-             || ((libusb_get_bus_number(device) == bus_number) &&
+             || ((libusb_get_bus_number(device)+1 == bus_number) &&
                  (libusb_get_device_address(device) == device_address))) )
         {
             int32_t tmp;
@@ -433,10 +433,10 @@ retry:
                     && (product == device->descriptor.idProduct)
                     && ((bus_number == 0)
                         || (device->devnum == device_address
-                            && (usb_bus->location >> 24) == bus_number)))
+                            && (usb_bus->location >> 24)+1 == bus_number)))
                 {
                     int32_t tmp;
-                    DEBUG( "found device at USB:%d,%d\n", device->devnum, (usb_bus->location >> 24) );
+                    DEBUG( "found device at USB:%d,%d\n", (usb_bus->location >> 24), device->devnum );
                     /* We found a device that looks like it matches...
                      * let's try to find the DFU interface, open the device
                      * and claim it. */

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #ifdef HAVE_LIBUSB_1_0
-#include <libusb.h>
+#include <libusb-1.0/libusb.h>
 #else
 #include <usb.h>
 #endif

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -25,7 +25,7 @@
 # include <config.h>
 #endif
 #ifdef HAVE_LIBUSB_1_0
-#include <libusb.h>
+#include <libusb-1.0/libusb.h>
 #else
 #include <usb.h>
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 #ifdef HAVE_LIBUSB_1_0
-#include <libusb.h>
+#include <libusb-1.0/libusb.h>
 #else
 #include <usb.h>
 #endif
@@ -78,7 +78,11 @@ int main( int argc, char **argv )
 
     if( debug >= 200 ) {
 #ifdef HAVE_LIBUSB_1_0
+    #if LIBUSB_API_VERSION >= 0x01000106
+        libusb_set_option(usbcontext, LIBUSB_OPTION_LOG_LEVEL, debug);
+    #else
         libusb_set_debug(usbcontext, debug );
+    #endif
 #else
         usb_set_debug( debug );
 #endif


### PR DESCRIPTION
I realize this is a big PR, and I can break it apart if needed, but I thought why not start here.

This fixes the issues described in #62 and includes the work from #63.

This will automatically build binaries for all target systems and publish them as "Releases" on GitHub.

#### Changes

- Fix bug preventing specifying a device with libusb0 - e0048b11fc897f2d6972c44547a1b8f4b89771bc + 3619cd7d9ff95f812f53d3dfd335d1bb8c38060b
  #62
- Fix bug in order device id was printed with libusb0 - 54d0b670e0d4f60f2a5f931532d5a551df7668fd
- Publish binaries for Windows for libusb1 - 4c1f1745482f8411037cbbfc309c612a161eee0c
- [Enable GitHub Actions](64/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721)
- Make `./bootstrap.sh` fail if any command fails (and print commands) - c7354e7eaf8573f109e861ea8978abaa71e35160
- Update `configure.ac` features - 762e406e14fb9638612d7317f2d50fde1a7e54f4
- Update uses of deprecated libusb1 functions - a6b087b8ec94c18019a4cac752fe09f9671b1ccc