### PR TITLE
Libdfu

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,7 @@
 AM_CFLAGS = -Wall
 bin_PROGRAMS = dfu-programmer
 dfu_programmer_SOURCES = main.c
+dfu_programmer_SOURCES += libdfu.c
 dfu_programmer_SOURCES += arguments.c
 dfu_programmer_SOURCES += atmel.c
 dfu_programmer_SOURCES += commands.c

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -52,7 +52,7 @@
 #define BL_EXTRA        2   /* Bootloader at top in separate memory area */
 #define BL_SPECIFIC     3   /* Any value greater than this is a specific start address */
 
-extern int debug;       /* defined in main.c */
+extern int debug;       /* defined in libdfu.c */
 
 #define ARGUMENTS_DEBUG_THRESHOLD 100
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -23,6 +23,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "dfu-device.h"
 #include "atmel.h"
 
@@ -245,4 +249,9 @@ struct programmer_arguments {
 int32_t parse_arguments( struct programmer_arguments *args,
                          const size_t argc,
                          char **argv );
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/src/atmel.c
+++ b/src/atmel.c
@@ -69,7 +69,7 @@
 #define PROGRESS_END    "]  "
 #define PROGRESS_ERROR  " X  "
 
-extern int debug;       /* defined in main.c */
+extern int debug;       /* defined in libdfu.c */
 
 // ________  P R O T O T Y P E S  _______________________________
 static int32_t atmel_read_command( dfu_device_t *device,

--- a/src/atmel.h
+++ b/src/atmel.h
@@ -25,6 +25,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "dfu-device.h"
 #include "intel_hex.h"
 
@@ -178,5 +182,9 @@ int32_t atmel_user( dfu_device_t *device,
  */
 
 void atmel_print_device_info( FILE *stream, atmel_device_info_t *info );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/commands.h
+++ b/src/commands.h
@@ -22,9 +22,19 @@
 #define __COMMANDS_H__
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "arguments.h"
 #include "dfu-device.h"
 
 int32_t execute_command( dfu_device_t *device,
                          struct programmer_arguments *args );
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/src/dfu-device.h
+++ b/src/dfu-device.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include <libusb-1.0/libusb.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Atmel device classes are now defined with one bit per class.
 // This simplifies checking in functions which handle more than one class.
 #define ADC_8051    (1<<0)
@@ -26,6 +30,10 @@ typedef struct {
     int security_bit_state;
     uint16_t transaction;
 } dfu_device_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __DFU_DEVICE_H__ */
 

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -307,10 +307,11 @@ struct libusb_device *dfu_device_init( const uint32_t vendor,
                                        const uint32_t device_address,
                                        dfu_device_t *dfu_device,
                                        const bool initial_abort,
-                                       const bool honor_interfaceclass ) {
+                                       const bool honor_interfaceclass,
+                                       libusb_context *usb_context
+                                        ) {
     libusb_device **list;
     size_t i,deviceCount;
-    extern libusb_context *usbContext;
     int32_t retries = 4;
 
     TRACE( "%s( %u, %u, %p, %s, %s )\n", __FUNCTION__, vendor, product,
@@ -320,7 +321,7 @@ struct libusb_device *dfu_device_init( const uint32_t vendor,
     DEBUG( "%s(%08x, %08x)\n",__FUNCTION__, vendor, product );
 
 retry:
-    deviceCount = libusb_get_device_list( usbContext, &list );
+    deviceCount = libusb_get_device_list( usb_context, &list );
 
     for( i = 0; i < deviceCount; i++ ) {
         libusb_device *device = list[i];

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -26,6 +26,10 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "dfu-device.h"
 
 /* DFU states */
@@ -186,5 +190,9 @@ char* dfu_state_to_string( const int32_t state );
  *
  *  returns the state name or "unknown state"
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -159,7 +159,8 @@ struct libusb_device
                                        const uint32_t dev_addr,
                                        dfu_device_t *device,
                                        const bool initial_abort,
-                                       const bool honor_interfaceclass );
+                                       const bool honor_interfaceclass,
+                                       libusb_context *usb_context );
 /*  dfu_device_init is designed to find one of the usb devices which match
  *  the vendor and product parameters passed in.
  *

--- a/src/intel_hex.h
+++ b/src/intel_hex.h
@@ -24,6 +24,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     size_t total_size;          // the total size of the buffer
     size_t  page_size;          // the size of a flash page
@@ -126,5 +130,10 @@ int32_t intel_flash_prep_buffer( intel_buffer_out_t *bout );
  * the buffer pointer must align with the beginning of a flash page
  * return 0 on success, -1 if assigning data would extend flash above size
  */
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/libdfu.c
+++ b/src/libdfu.c
@@ -1,0 +1,106 @@
+/*
+ * dfu-programmer
+ *
+ * $Id$
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include <libusb-1.0/libusb.h>
+#include <string.h>
+
+#include "config.h"
+#include "dfu-device.h"
+#include "dfu.h"
+#include "arguments.h"
+#include "commands.h"
+#include "atmel.h"
+#include "libdfu.h"
+#include "config.h"
+
+// NOTE: Technically not thread safe... but since it's not changed when used as a library, it's safe.
+int debug;
+
+static const char *progname = PACKAGE;
+
+int dfu_programmer(struct programmer_arguments * args)
+{
+    int retval = SUCCESS;
+    dfu_device_t dfu_device;
+    struct libusb_device *device = NULL;
+    libusb_context *usbContext;
+
+    memset(&dfu_device, 0, sizeof(dfu_device));
+
+    if (libusb_init(&usbContext))
+    {
+        fprintf(stderr, "%s: can't init libusb.\n", progname);
+        return DEVICE_ACCESS_ERROR;
+    }
+
+    if (debug >= 200)
+    {
+#if LIBUSB_API_VERSION >= 0x01000106
+        libusb_set_option(usbContext, LIBUSB_OPTION_LOG_LEVEL, debug);
+#else
+        libusb_set_debug(usbContext, debug);
+#endif
+    }
+
+    device = dfu_device_init(args->vendor_id, args->chip_id,
+                                args->bus_id, args->device_address,
+                                &dfu_device,
+                                args->initial_abort,
+                                args->honor_interfaceclass,
+                                usbContext);
+
+    if (NULL == device)
+    {
+        fprintf(stderr, "%s: no device present.\n", progname);
+        retval = DEVICE_ACCESS_ERROR;
+        goto error;
+    }
+
+    retval = execute_command(&dfu_device, args);
+
+error:
+    if (NULL != dfu_device.handle)
+    {
+        int rv;
+
+        rv = libusb_release_interface(dfu_device.handle, dfu_device.interface);
+        /* The RESET command sometimes causes the usb_release_interface command to fail.
+           It is not obvious why this happens but it may be a glitch due to the hardware
+           reset in the attached device. In any event, since reset causes a USB detach
+           this should not matter, so there is no point in raising an alarm.
+        */
+        if (0 != rv && !(com_launch == args->command &&
+                         args->com_launch_config.noreset == 0))
+        {
+            fprintf(stderr, "%s: failed to release interface %d.\n",
+                    progname, dfu_device.interface);
+            retval = DEVICE_ACCESS_ERROR;
+        }
+    }
+
+    if (NULL != dfu_device.handle)
+    {
+        libusb_close(dfu_device.handle);
+    }
+
+    libusb_exit(usbContext);
+
+    return retval;
+}

--- a/src/libdfu.h
+++ b/src/libdfu.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "arguments.h"
 
 int dfu_programmer(struct programmer_arguments * args);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/libdfu.h
+++ b/src/libdfu.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "arguments.h"
+
+int dfu_programmer(struct programmer_arguments * args);

--- a/src/main.c
+++ b/src/main.c
@@ -18,32 +18,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <stdio.h>
 #include <string.h>
-#include <libusb-1.0/libusb.h>
-
-#include "config.h"
-#include "dfu-device.h"
-#include "dfu.h"
-#include "atmel.h"
-#include "arguments.h"
-#include "commands.h"
-
-
-int debug;
-libusb_context *usbContext;
+#include "libdfu.h"
 
 int main( int argc, char **argv )
 {
-    static const char *progname = PACKAGE;
-    int retval = SUCCESS;
     int status;
-    dfu_device_t dfu_device;
     struct programmer_arguments args;
-    struct libusb_device *device = NULL;
 
     memset( &args, 0, sizeof(args) );
-    memset( &dfu_device, 0, sizeof(dfu_device) );
 
     status = parse_arguments(&args, argc, argv);
     if( status < 0 ) {
@@ -54,59 +37,5 @@ int main( int argc, char **argv )
         return SUCCESS;
     }
 
-    if (libusb_init(&usbContext)) {
-        fprintf( stderr, "%s: can't init libusb.\n", progname );
-        return DEVICE_ACCESS_ERROR;
-    }
-
-    if( debug >= 200 ) {
-    #if LIBUSB_API_VERSION >= 0x01000106
-        libusb_set_option(usbContext, LIBUSB_OPTION_LOG_LEVEL, debug);
-    #else
-        libusb_set_debug(usbContext, debug );
-    #endif
-    }
-
-    device = dfu_device_init( args.vendor_id, args.chip_id,
-                                args.bus_id, args.device_address,
-                                &dfu_device,
-                                args.initial_abort,
-                                args.honor_interfaceclass );
-
-    if( NULL == device ) {
-        fprintf( stderr, "%s: no device present.\n", progname );
-        retval = DEVICE_ACCESS_ERROR;
-        goto error;
-    }
-
-    if( 0 != (retval = execute_command(&dfu_device, &args)) ) {
-        /* command issued a specific diagnostic already */
-        goto error;
-    }
-
-error:
-    if( NULL != dfu_device.handle ) {
-        int rv;
-
-        rv = libusb_release_interface( dfu_device.handle, dfu_device.interface );
-        /* The RESET command sometimes causes the usb_release_interface command to fail.
-           It is not obvious why this happens but it may be a glitch due to the hardware
-           reset in the attached device. In any event, since reset causes a USB detach
-           this should not matter, so there is no point in raising an alarm.
-        */
-        if( 0 != rv && !(com_launch == args.command &&
-                args.com_launch_config.noreset == 0) ) {
-            fprintf( stderr, "%s: failed to release interface %d.\n",
-                             progname, dfu_device.interface );
-            retval = DEVICE_ACCESS_ERROR;
-        }
-    }
-
-    if( NULL != dfu_device.handle ) {
-        libusb_close(dfu_device.handle);
-    }
-
-    libusb_exit(usbContext);
-
-    return retval;
+    return dfu_programmer(&args);
 }

--- a/src/stm32.c
+++ b/src/stm32.c
@@ -93,7 +93,7 @@ static int32_t stm32_erase( dfu_device_t *device, uint8_t *command,
 
 
 //___ V A R I A B L E S ______________________________________________________
-extern int debug;       /* defined in main.c */
+extern int debug;       /* defined in libdfu.c */
 
 /* FIXME : these should be read from usb device descriptor because they are
  * device specific */

--- a/src/stm32.h
+++ b/src/stm32.h
@@ -22,6 +22,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "dfu-device.h"
 #include "intel_hex.h"
 
@@ -131,6 +135,10 @@ int32_t stm32_getsecure( dfu_device_t *device );
 int32_t stm32_user( dfu_device_t *device, intel_buffer_out_t *bout );
 
 void stm32_print_device_info( FILE *stream, stm32_device_info_t *info );
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif  /* __STM32_H__ */

--- a/src/util.c
+++ b/src/util.c
@@ -23,7 +23,7 @@
 
 #include "util.h"
 
-extern int debug;       /* defined in main.c */
+extern int debug;       /* defined in libdfu.c */
 
 void dfu_debug( const char *file, const char *function, const int line,
                 const int level, const char *format, ... )

--- a/src/util.h
+++ b/src/util.h
@@ -23,6 +23,15 @@
 
 #include <stdarg.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void dfu_debug( const char *file, const char *function, const int line,
                 const int level, const char *format, ... );
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif


### PR DESCRIPTION
Make it easier to call dfu-programmer as a library.

Basically took all of the code that wasn't argument parsing in `main.c` and put that into a separate file (`libusb.c`) with a single function call with a declaration in `libusb.h`.

~I also cleaned up some features that were really just part of the argument parsing.~ Moved to #73

~Note, this code is technically not _(yet)_ thread safe. It *might* work fine but some refactoring is needed to truly isolate contexts.~ Fixed in 40dd1cd33d532d71dec3fd0516678a4ff46a297e.