### PR TITLE
Remove redundant definitions - use in-language true/false

### DIFF
--- a/src/arguments.c
+++ b/src/arguments.c
@@ -23,8 +23,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
-#include "dfu-bool.h"
 #include "dfu-device.h"
 #include "config.h"
 #include "arguments.h"

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -21,7 +21,8 @@
 #ifndef __ARGUMENTS_H__
 #define __ARGUMENTS_H__
 
-#include "dfu-bool.h"
+#include <stdbool.h>
+
 #include "dfu-device.h"
 #include "atmel.h"
 
@@ -170,8 +171,8 @@ struct programmer_arguments {
     uint32_t bootloader_top;            /* top of the bootloader region    */
     uint32_t bootloader_bottom;         /* bottom of the bootloader region */
     size_t flash_page_size;             /* size of a page in bytes         */
-    dfu_bool initial_abort;
-    dfu_bool honor_interfaceclass;
+    bool initial_abort;
+    bool honor_interfaceclass;
     size_t eeprom_memory_size;
     size_t eeprom_page_size;
 
@@ -193,18 +194,18 @@ struct programmer_arguments {
         } com_setfuse_data;
 
         struct com_read_struct {
-            dfu_bool bin;
-            dfu_bool force;             /* do not remove blank pages */
+            bool bin;
+            bool force;             /* do not remove blank pages */
             enum atmel_memory_unit_enum segment;
         } com_read_data;
 
         struct com_erase_struct {
-            dfu_bool force;
+            bool force;
             int32_t suppress_validation;
         } com_erase_data;
 
         struct com_launch_struct {
-            dfu_bool noreset;
+            bool noreset;
         } com_launch_config;
 
         struct com_flash_struct {
@@ -214,19 +215,19 @@ struct programmer_arguments {
             int16_t *serial_data; /* serial number or other device specific bytes */
             size_t serial_offset; /* where the serial_data should be written */
             size_t serial_length; /* how many bytes to write */
-            dfu_bool force;       /* bootloader configuration for UC3 devices
+            bool force;       /* bootloader configuration for UC3 devices
                                      is on last one or two words in the user
                                      page depending on the version of the
                                      bootloader - force overwrite required */
-            dfu_bool validate_first; /* Do a validate before flashing */
-            dfu_bool ignore_outside; /* Ignore validate errors outside region */
+            bool validate_first; /* Do a validate before flashing */
+            bool ignore_outside; /* Ignore validate errors outside region */
             enum atmel_memory_unit_enum segment;
         } com_flash_data;
 
         struct com_convert_struct {
             size_t bin_offset;          // where the bin data starts
             char original_first_char;
-            dfu_bool force;             /* do not remove blank pages */
+            bool force;             /* do not remove blank pages */
             char *file;                 // for bin2hex / hex2bin conversions
             enum atmel_memory_unit_enum segment;    // to auto-select offset
         } com_convert_data;

--- a/src/atmel.c
+++ b/src/atmel.c
@@ -26,8 +26,8 @@
 #include <errno.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdbool.h>
 
-#include "dfu-bool.h"
 #include "dfu-device.h"
 #include "config.h"
 #include "arguments.h"
@@ -82,7 +82,7 @@ static int32_t atmel_read_command( dfu_device_t *device,
 
 static int32_t __atmel_flash_block( dfu_device_t *device,
                                     intel_buffer_out_t *bout,
-                                    const dfu_bool eeprom );
+                                    const bool eeprom );
 /* flash the contents of memory into a block of memory.  it is assumed that the
  * appropriate page has already been selected.  start and end are the start and
  * end addresses of the flash data.  returns 0 on success, positive dfu error
@@ -114,7 +114,7 @@ static int32_t __atmel_blank_page_check( dfu_device_t *device,
 
 static int32_t __atmel_read_block( dfu_device_t *device,
                                    intel_buffer_in_t *buin,
-                                   const dfu_bool eeprom );
+                                   const bool eeprom );
 /* assumes block does not cross 64 b page boundaries and ideally aligns
  * with flash pages. appropriate memory type and 64kb page has already
  * been selected, max transfer size is not violated it updates the buffer
@@ -320,7 +320,7 @@ int32_t atmel_read_config( dfu_device_t *device,
 
 int32_t atmel_erase_flash( dfu_device_t *device,
                            const uint8_t mode,
-                           dfu_bool quiet ) {
+                           bool quiet ) {
     uint8_t command[3] = { 0x04, 0x00, 0x00 };
     dfu_status_t status;
     int32_t retries;
@@ -573,7 +573,7 @@ int32_t atmel_set_config( dfu_device_t *device,
 
 static int32_t __atmel_read_block( dfu_device_t *device,
                                    intel_buffer_in_t *buin,
-                                   const dfu_bool eeprom ) {
+                                   const bool eeprom ) {
     uint8_t command[6] = { 0x03, 0x00, 0x00, 0x00, 0x00, 0x00 };
     int32_t result;
 
@@ -630,7 +630,7 @@ static int32_t __atmel_read_block( dfu_device_t *device,
 int32_t atmel_read_flash( dfu_device_t *device,
                           intel_buffer_in_t *buin,
                           const uint8_t mem_segment,
-                          const dfu_bool quiet ) {
+                          const bool quiet ) {
     uint8_t mem_page = 0;           // tracks the current memory page
     uint32_t progress = 0;          // used to indicate progress
     int32_t result = 0;
@@ -809,7 +809,7 @@ static int32_t __atmel_blank_page_check( dfu_device_t *device,
 int32_t atmel_blank_check( dfu_device_t *device,
                            const uint32_t start,
                            const uint32_t end,
-                           dfu_bool quiet ) {
+                           bool quiet ) {
     int32_t result;                     // blank_page_check_result
     uint32_t blank_upto = start;        // up to is not inclusive
     uint32_t check_until;               // end address of page check
@@ -1139,9 +1139,9 @@ int32_t atmel_getsecure( dfu_device_t *device ) {
 
 int32_t atmel_flash( dfu_device_t *device,
                      intel_buffer_out_t *bout,
-                     const dfu_bool eeprom,
-                     const dfu_bool force,
-                     const dfu_bool quiet ) {
+                     const bool eeprom,
+                     const bool force,
+                     const bool quiet ) {
     uint32_t i;
     uint32_t progress = 0;  // keep record of sent progress as bytes * 32
     uint8_t mem_page = 0;   // tracks the current memory page
@@ -1380,7 +1380,7 @@ static void atmel_flash_populate_footer( uint8_t *message, uint8_t *footer,
 static void atmel_flash_populate_header( uint8_t *header,
                                          const uint32_t start,
                                          const uint32_t end,
-                                         const dfu_bool eeprom ) {
+                                         const bool eeprom ) {
 
     TRACE( "%s( %p, 0x%X, 0x%X, %s )\n", __FUNCTION__, header, start,
            end, ((true == eeprom) ? "true" : "false") );
@@ -1406,7 +1406,7 @@ static void atmel_flash_populate_header( uint8_t *header,
 
 static int32_t __atmel_flash_block( dfu_device_t *device,
                                     intel_buffer_out_t *bout,
-                                    const dfu_bool eeprom ) {
+                                    const bool eeprom ) {
     // from doc7618, AT90 / ATmega app note protocol:
     const size_t length = bout->info.block_end - bout->info.block_start + 1;
     uint8_t message[ATMEL_MAX_FLASH_BUFFER_SIZE];

--- a/src/atmel.h
+++ b/src/atmel.h
@@ -23,7 +23,8 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include "dfu-bool.h"
+#include <stdbool.h>
+
 #include "dfu-device.h"
 #include "intel_hex.h"
 
@@ -99,7 +100,7 @@ int32_t atmel_read_fuses( dfu_device_t *device,
 
 int32_t atmel_erase_flash( dfu_device_t *device,
                            const uint8_t mode,
-                           dfu_bool quiet );
+                           bool quiet );
 /*  atmel_erase_flash
  *  device    - the usb_dev_handle to communicate with
  *  mode      - the mode to use when erasing flash
@@ -123,7 +124,7 @@ int32_t atmel_set_config( dfu_device_t *device,
 int32_t atmel_read_flash( dfu_device_t *device,
                           intel_buffer_in_t *buin,
                           uint8_t mem_segment,
-                          const dfu_bool quiet);
+                          const bool quiet);
 /* read the flash from buin->info.data_start to data_end and place
  * in buin.data. mem_segment is the segment of memory from the
  * atmel_memory_unit_enum.
@@ -132,7 +133,7 @@ int32_t atmel_read_flash( dfu_device_t *device,
 int32_t atmel_blank_check( dfu_device_t *device,
                            const uint32_t start,
                            const uint32_t end,
-                           dfu_bool quiet );
+                           bool quiet );
 /* check if memory between start byte and end byte (inclusive) is blank
  * returns 0 for success, < 0 for communication errors, > 0 for not blank
  */
@@ -154,9 +155,9 @@ int32_t atmel_getsecure( dfu_device_t *device );
 
 int32_t atmel_flash( dfu_device_t *device,
                      intel_buffer_out_t *bout,
-                     const dfu_bool eeprom,
-                     const dfu_bool force,
-                     const dfu_bool hide_progress );
+                     const bool eeprom,
+                     const bool force,
+                     const bool hide_progress );
 /* Flash data from the buffer to the main program memory on the device.
  * buffer contains the data to flash where buffer[0] is aligned with memory
  * address zero (which could be inside the bootloader and unavailable).

--- a/src/commands.c
+++ b/src/commands.c
@@ -22,8 +22,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
-#include "dfu-bool.h"
 #include "config.h"
 #include "commands.h"
 #include "arguments.h"
@@ -44,8 +44,8 @@ static int security_bit_state;
 static int32_t execute_validate( dfu_device_t *device,
                                  intel_buffer_out_t *bout,
                                  uint8_t mem_segment,
-                                 dfu_bool quiet,
-                                 dfu_bool ignore_outside);
+                                 bool quiet,
+                                 bool ignore_outside);
 /* provide an out buffer to validate and whether this is from
  * flash or eeprom data sections, also wether you want it quiet
  */
@@ -162,8 +162,8 @@ static int32_t serialize_memory_image( intel_buffer_out_t *bout,
 static int32_t execute_validate( dfu_device_t *device,
                                  intel_buffer_out_t *bout,
                                  uint8_t mem_segment,
-                                 const dfu_bool quiet,
-                                 const dfu_bool ignore_outside) {
+                                 const bool quiet,
+                                 const bool ignore_outside) {
     int32_t retval = UNSPECIFIED_ERROR;
     int32_t result;             // result of fcn calls
     intel_buffer_in_t buin;     // buffer in for storing read mem

--- a/src/dfu-bool.h
+++ b/src/dfu-bool.h
@@ -4,6 +4,6 @@
 typedef enum {
     false = 0,
     true  = 1
-} dfu_bool;
+} bool;
 
 #endif

--- a/src/dfu-bool.h
+++ b/src/dfu-bool.h
@@ -1,9 +1,0 @@
-#ifndef __DFU_BOOL_H__
-#define __DFU_BOOL_H__
-
-typedef enum {
-    false = 0,
-    true  = 1
-} bool;
-
-#endif

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -25,10 +25,10 @@
 #include <stddef.h>
 #include <libusb-1.0/libusb.h>
 #include <errno.h>
+#include <stdbool.h>
 
 #include "dfu.h"
 #include "util.h"
-#include "dfu-bool.h"
 
 // cSpell:words DNBUSY
 
@@ -68,7 +68,7 @@ static uint16_t transaction = 0;
 
 // ________  P R O T O T Y P E S  _______________________________
 static int32_t dfu_find_interface( struct libusb_device *device,
-                                   const dfu_bool honor_interfaceclass,
+                                   const bool honor_interfaceclass,
                                    const uint8_t bNumConfigurations);
 /*  Used to find the dfu interface for a device if there is one.
  *
@@ -79,7 +79,7 @@ static int32_t dfu_find_interface( struct libusb_device *device,
  *  returns the interface number if found, < 0 otherwise
  */
 
-static int32_t dfu_make_idle( dfu_device_t *device, const dfu_bool initial_abort );
+static int32_t dfu_make_idle( dfu_device_t *device, const bool initial_abort );
 /*  Gets the device into the dfuIDLE state if possible.
  *
  *  device    - the dfu device to communicate with
@@ -308,8 +308,8 @@ struct libusb_device *dfu_device_init( const uint32_t vendor,
                                        const uint32_t bus_number,
                                        const uint32_t device_address,
                                        dfu_device_t *dfu_device,
-                                       const dfu_bool initial_abort,
-                                       const dfu_bool honor_interfaceclass ) {
+                                       const bool initial_abort,
+                                       const bool honor_interfaceclass ) {
     libusb_device **list;
     size_t i,deviceCount;
     extern libusb_context *usbContext;
@@ -495,7 +495,7 @@ char* dfu_status_to_string( const int32_t status ) {
 }
 
 static int32_t dfu_find_interface( struct libusb_device *device,
-                                   const dfu_bool honor_interfaceclass,
+                                   const bool honor_interfaceclass,
                                    const uint8_t bNumConfigurations) {
     int32_t c,i,s;
 
@@ -552,7 +552,7 @@ static int32_t dfu_find_interface( struct libusb_device *device,
 
 
 static int32_t dfu_make_idle( dfu_device_t *device,
-                              const dfu_bool initial_abort ) {
+                              const bool initial_abort ) {
     dfu_status_t status;
     int32_t retries = 4;
 

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -24,8 +24,8 @@
 #include <libusb-1.0/libusb.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
-#include "dfu-bool.h"
 #include "dfu-device.h"
 
 /* DFU states */
@@ -158,8 +158,8 @@ struct libusb_device
                                        const uint32_t bus,
                                        const uint32_t dev_addr,
                                        dfu_device_t *device,
-                                       const dfu_bool initial_abort,
-                                       const dfu_bool honor_interfaceclass );
+                                       const bool initial_abort,
+                                       const bool honor_interfaceclass );
 /*  dfu_device_init is designed to find one of the usb devices which match
  *  the vendor and product parameters passed in.
  *

--- a/src/intel_hex.c
+++ b/src/intel_hex.c
@@ -271,7 +271,7 @@ int32_t intel_process_data( intel_buffer_out_t *bout, char value,
 }
 
 int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
-                             uint32_t target_offset, dfu_bool quiet ) {
+                             uint32_t target_offset, bool quiet ) {
     FILE *fp = NULL;
     struct intel_record record;
     // unsigned int count, type, checksum, address; char data[256]
@@ -469,7 +469,7 @@ static int32_t ihex_make_record_04_offset( uint32_t offset, char *str ) {
 //}
 
 int32_t intel_hex_from_buffer( intel_buffer_in_t *buin,
-                               dfu_bool force_full, uint32_t target_offset ) {
+                               bool force_full, uint32_t target_offset ) {
     char line[80];
     uint32_t offset_address = 0;    // offset address written to a previous line
     uint32_t address = 0;   // relative offset from previously set addr
@@ -618,7 +618,7 @@ int32_t intel_init_buffer_in( intel_buffer_in_t *buin,
 
 int32_t intel_validate_buffer( intel_buffer_in_t *buin,
                                intel_buffer_out_t *bout,
-                               dfu_bool quiet) {
+                               bool quiet) {
     int32_t i;
     int32_t invalid_data_region = 0;
     int32_t invalid_outside_data_region = 0;

--- a/src/intel_hex.h
+++ b/src/intel_hex.h
@@ -22,7 +22,7 @@
 #define __INTEL_HEX_H__
 
 #include <stdint.h>
-#include "dfu-bool.h"
+#include <stdbool.h>
 
 typedef struct {
     size_t total_size;          // the total size of the buffer
@@ -58,7 +58,7 @@ int32_t intel_process_data( intel_buffer_out_t *bout,
 // processing any data and putting it into a buffer
 
 int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
-        uint32_t target_offset, dfu_bool quiet );
+        uint32_t target_offset, bool quiet );
 /*  Used to read in a file in intel hex format and return a chunk of
  *  memory containing the memory image described in the file.
  *
@@ -87,7 +87,7 @@ int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
  */
 
 int32_t intel_hex_from_buffer( intel_buffer_in_t *buin,
-        dfu_bool force_full, uint32_t target_offset );
+        bool force_full, uint32_t target_offset );
 /*  Used to convert a buffer to an intel hex formatted file.
  *  target offset is the address location of buffer 0
  *  force_full sets whether to keep writing entirely blank pages.
@@ -113,7 +113,7 @@ int32_t intel_init_buffer_in(intel_buffer_in_t *buin,
  */
 
 int32_t intel_validate_buffer(  intel_buffer_in_t *buin,
-                                intel_buffer_out_t *bout, dfu_bool quiet);
+                                intel_buffer_out_t *bout, bool quiet);
 /* compare the contents of buffer_in with buffer_out to check that a target
  * memory image matches with a memory read.
  * return 0 for full validation, positive number if data bytes outside region do

--- a/src/stm32.c
+++ b/src/stm32.c
@@ -22,8 +22,8 @@
 #include <string.h>
 #include <stddef.h>
 #include <errno.h>
+#include <stdbool.h>
 
-#include "dfu-bool.h"
 #include "dfu-device.h"
 #include "config.h"
 #include "arguments.h"
@@ -86,7 +86,7 @@ static inline void print_progress( intel_buffer_info_t *info,
    */
 
 static int32_t stm32_erase( dfu_device_t *device, uint8_t *command,
-                            uint8_t command_length, dfu_bool quiet );
+                            uint8_t command_length, bool quiet );
   /* erase, erase page, and read unprotect all share this functionality
    * although with different commands
    */
@@ -272,7 +272,7 @@ static inline void print_progress( intel_buffer_info_t *info,
 }
 
 static int32_t stm32_erase( dfu_device_t *device, uint8_t *command,
-                            uint8_t command_length, dfu_bool quiet ) {
+                            uint8_t command_length, bool quiet ) {
   int32_t status;
   dfu_set_transaction_num( 0 );     /* set wValue to zero */
   if( command_length != dfu_download(device, command_length, command) ) {
@@ -301,7 +301,7 @@ static int32_t stm32_erase( dfu_device_t *device, uint8_t *command,
 }
 
 //___ F U N C T I O N S ______________________________________________________
-int32_t stm32_erase_flash( dfu_device_t *device, dfu_bool quiet ) {
+int32_t stm32_erase_flash( dfu_device_t *device, bool quiet ) {
   TRACE( "%s( %p, %s )\n", __FUNCTION__, device, quiet ? "true" : "false" );
   uint8_t command[] = { ERASE_CMD };
   uint8_t length = 1;
@@ -315,7 +315,7 @@ int32_t stm32_erase_flash( dfu_device_t *device, dfu_bool quiet ) {
 }
 
 int32_t stm32_page_erase( dfu_device_t *device, uint32_t address,
-                           dfu_bool quiet ) {
+                           bool quiet ) {
   TRACE( "%s( %p, 0x%X, %s )\n", __FUNCTION__, device, address,
       quiet ? "true" : "false" );
   uint8_t length = 5;
@@ -331,7 +331,7 @@ int32_t stm32_page_erase( dfu_device_t *device, uint32_t address,
   return stm32_erase( device, command, length, quiet );
 }
 
-int32_t stm32_start_app( dfu_device_t *device, dfu_bool quiet ) {
+int32_t stm32_start_app( dfu_device_t *device, bool quiet ) {
   TRACE( "%s( %p )\n", __FUNCTION__, device );
   int32_t status;
 
@@ -365,7 +365,7 @@ int32_t stm32_start_app( dfu_device_t *device, dfu_bool quiet ) {
 }
 
 int32_t stm32_read_flash( dfu_device_t *device, intel_buffer_in_t *buin,
-    const uint8_t mem_segment, const dfu_bool quiet ) {
+    const uint8_t mem_segment, const bool quiet ) {
   TRACE( "%s( %p, %p, %u, %s )\n", __FUNCTION__, device, buin,
       mem_segment, ((true == quiet) ? "true" : "false"));
 
@@ -475,7 +475,7 @@ finally:
 }
 
 int32_t stm32_write_flash( dfu_device_t *device, intel_buffer_out_t *bout,
-    const dfu_bool eeprom, const dfu_bool force, const dfu_bool quiet ) {
+    const bool eeprom, const bool force, const bool quiet ) {
   TRACE( "%s( %p, %p, %s, %s )\n", __FUNCTION__, device, bout,
           ((true == eeprom) ? "true" : "false"),
           ((true == quiet) ? "true" : "false") );
@@ -736,7 +736,7 @@ int32_t stm32_get_configuration( dfu_device_t *device ) {
   return SUCCESS;
 }
 
-int32_t stm32_read_unprotect( dfu_device_t *device, dfu_bool quiet ) {
+int32_t stm32_read_unprotect( dfu_device_t *device, bool quiet ) {
   TRACE( "%s( %p, %s )\n", __FUNCTION__, device, quiet ? "true" : "false" );
   uint8_t command[] = { READ_UNPROTECT };
   uint8_t length = 1;

--- a/src/stm32.h
+++ b/src/stm32.h
@@ -20,7 +20,8 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include "dfu-bool.h"
+#include <stdbool.h>
+
 #include "dfu-device.h"
 #include "intel_hex.h"
 
@@ -53,31 +54,31 @@ typedef enum {
 #define STM32_READ_PROT_ERROR   -10
 
 
-int32_t stm32_erase_flash( dfu_device_t *device, dfu_bool quiet );
+int32_t stm32_erase_flash( dfu_device_t *device, bool quiet );
   /*  mass erase flash
    *  device  - the usb_dev_handle to communicate with
    *  returns status DFU_STATUS_OK if ok, anything else on error
    */
 
 int32_t stm32_page_erase( dfu_device_t *device, uint32_t address,
-    dfu_bool quiet );
+    bool quiet );
   /* erase a page of memory (provide the page address) */
 
-int32_t stm32_start_app( dfu_device_t *device, dfu_bool quiet );
+int32_t stm32_start_app( dfu_device_t *device, bool quiet );
   /* Reset the registers to default reset values and start application
    */
 
 int32_t stm32_read_flash( dfu_device_t *device,
               intel_buffer_in_t *buin,
               uint8_t mem_segment,
-              const dfu_bool quiet);
+              const bool quiet);
   /* read the flash from buin->info.data_start to data_end and place
    * in buin.data. mem_segment is the segment of memory from the
    * stm32_memory_unit_enum.
    */
 
 int32_t stm32_write_flash( dfu_device_t *device, intel_buffer_out_t *bout,
-    const dfu_bool eeprom, const dfu_bool force, const dfu_bool hide_progress );
+    const bool eeprom, const bool force, const bool hide_progress );
   /* Flash data from the buffer to the main program memory on the device.
    * buffer contains the data to flash where buffer[0] is aligned with memory
    * address zero (which could be inside the bootloader and unavailable).
@@ -100,7 +101,7 @@ int32_t stm32_get_configuration( dfu_device_t *device );
    * @return 0 on success, negative for error
    */
 
-int32_t stm32_read_unprotect( dfu_device_t *device, dfu_bool quiet );
+int32_t stm32_read_unprotect( dfu_device_t *device, bool quiet );
   /* @brief unprotect the device (triggers a mass erase)
    * @param device pointer
    * @return 0 on success
@@ -121,7 +122,7 @@ int32_t stm32_set_config( dfu_device_t *device, const uint8_t property,
     const uint8_t value );
 
 int32_t stm32_blank_check( dfu_device_t *device, const uint32_t start,
-    const uint32_t end, dfu_bool quiet );
+    const uint32_t end, bool quiet );
 
 int32_t stm32_secure( dfu_device_t *device );
 


### PR DESCRIPTION
I'm not a fan of defining constants that the language already has. Any objections to this change?