### PR TITLE
src/atmel.c: Fix compilation with strict(er) C99 compilers

### DIFF
--- a/src/atmel.c
+++ b/src/atmel.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
Include `<stdlib.h>` for the malloc function.

Admittedly, I have only tested this on top of Fedora's 0.7.2 sources.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
