### PR TITLE
Make all state that changes part of the dfu struct for thread safety

### DIFF
--- a/src/dfu-device.h
+++ b/src/dfu-device.h
@@ -23,6 +23,8 @@ typedef struct {
     struct libusb_device_handle *handle;
     int32_t interface;
     atmel_device_class_t type;
+    int security_bit_state;
+    uint16_t transaction;
 } dfu_device_t;
 
 #endif /* __DFU_DEVICE_H__ */

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -64,8 +64,6 @@
 #define MSG_DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
                                DFU_MESSAGE_DEBUG_THRESHOLD, __VA_ARGS__ )
 
-static uint16_t transaction = 0;
-
 // ________  P R O T O T Y P E S  _______________________________
 static int32_t dfu_find_interface( struct libusb_device *device,
                                    const dfu_bool honor_interfaceclass,
@@ -108,15 +106,15 @@ static void dfu_msg_response_output( const char *function, const int32_t result 
  */
 
 // ________  F U N C T I O N S  _______________________________
-void dfu_set_transaction_num( uint16_t newNum ) {
+void dfu_set_transaction_num( dfu_device_t *device, uint16_t newNum ) {
     TRACE( "%s( %u )\n", __FUNCTION__, newNum );
-    transaction = newNum;
-    DEBUG("wValue set to %d\n", transaction);
+    device->transaction = newNum;
+    DEBUG("wValue set to %d\n", device->transaction);
 }
 
-uint16_t dfu_get_transaction_num( void ) {
+uint16_t dfu_get_transaction_num( dfu_device_t *device ) {
     TRACE( "%s( %u )\n", __FUNCTION__ );
-    return transaction;
+    return device->transaction;
 }
 
 int32_t dfu_detach( dfu_device_t *device, const int32_t timeout ) {
@@ -166,7 +164,7 @@ int32_t dfu_download( dfu_device_t *device,
         }
     }
 
-    result = dfu_transfer_out( device, DFU_DNLOAD, transaction++, data, length );
+    result = dfu_transfer_out( device, DFU_DNLOAD, device->transaction++, data, length );
 
     dfu_msg_response_output( __FUNCTION__, result );
 
@@ -189,7 +187,7 @@ int32_t dfu_upload( dfu_device_t *device, const size_t length, uint8_t* data ) {
         return -2;
     }
 
-    result = dfu_transfer_in( device, DFU_UPLOAD, transaction++, data, length );
+    result = dfu_transfer_in( device, DFU_UPLOAD, device->transaction++, data, length );
 
     dfu_msg_response_output( __FUNCTION__, result );
 

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -76,12 +76,12 @@ typedef struct {
     uint8_t iString;
 } dfu_status_t;
 
-void dfu_set_transaction_num( uint16_t newNum );
+void dfu_set_transaction_num( dfu_device_t *device, uint16_t newNum );
 /* set / reset the wValue parameter to a given value. this number is
  * significant for stm32 device commands (see dfu-device.h)
  */
 
-uint16_t dfu_get_transaction_num( void );
+uint16_t dfu_get_transaction_num( dfu_device_t *device );
 /* get the current transaction number (can be used to calculate address
  * offset for stm32 devices --- see dfu-device.h)
  */

--- a/src/stm32.c
+++ b/src/stm32.c
@@ -154,7 +154,7 @@ static int32_t stm32_set_address_ptr( dfu_device_t *device, uint32_t address ) {
     return -1;
   }
 
-  dfu_set_transaction_num( 0 );     /* set wValue to zero */
+  dfu_set_transaction_num( device, 0 );     /* set wValue to zero */
   if( length != dfu_download(device, length, command) ) {
     DEBUG( "dfu_download failed\n" );
     return -2;
@@ -274,7 +274,7 @@ static inline void print_progress( intel_buffer_info_t *info,
 static int32_t stm32_erase( dfu_device_t *device, uint8_t *command,
                             uint8_t command_length, dfu_bool quiet ) {
   int32_t status;
-  dfu_set_transaction_num( 0 );     /* set wValue to zero */
+  dfu_set_transaction_num( device, 0 );     /* set wValue to zero */
   if( command_length != dfu_download(device, command_length, command) ) {
     if( !quiet ) fprintf( stderr, "ERROR\n" );
     DEBUG( "dfu_download failed\n" );
@@ -348,7 +348,7 @@ int32_t stm32_start_app( dfu_device_t *device, dfu_bool quiet ) {
   }
 
   if( !quiet ) fprintf( stderr, "Launching program...  \n" );
-  dfu_set_transaction_num( 0 );     /* set wValue to zero */
+  dfu_set_transaction_num( device, 0 );     /* set wValue to zero */
   if( 0 != dfu_download(device, 0, NULL) ) {
     if( !quiet ) fprintf( stderr, "ERROR\n" );
     DEBUG( "dfu_download failed\n" );
@@ -411,7 +411,7 @@ int32_t stm32_read_flash( dfu_device_t *device, intel_buffer_in_t *buin,
         retval = UNSPECIFIED_ERROR;
         goto finally;
       }
-      dfu_set_transaction_num( 2 ); /* sets block offset 0 */
+      dfu_set_transaction_num( device, 2 ); /* sets block offset 0 */
       reset_address_flag = 0;
     }
 
@@ -441,7 +441,7 @@ int32_t stm32_read_flash( dfu_device_t *device, intel_buffer_in_t *buin,
 
     buin->info.block_start = buin->info.block_end + 1;
     if( reset_address_flag == 0 && (buin->info.block_start !=
-        (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num() - 2))
+        (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num( device ) - 2))
         + address_offset) ) {
       DEBUG("block start & address mismatch, reset req\n");
       reset_address_flag = 1;
@@ -581,7 +581,7 @@ int32_t stm32_write_flash( dfu_device_t *device, intel_buffer_out_t *bout,
         retval = DEVICE_ACCESS_ERROR;
         goto finally;
       }
-      dfu_set_transaction_num( 2 ); /* sets block offset 0 */
+      dfu_set_transaction_num( device, 2 ); /* sets block offset 0 */
       reset_address_flag = 0;
     }
 
@@ -626,7 +626,7 @@ int32_t stm32_write_flash( dfu_device_t *device, intel_buffer_out_t *bout,
     } // bout->info.block_start is now on the first valid data for the next segment
 
     if( reset_address_flag == 0 && (bout->info.block_start !=
-        (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num() - 2))
+        (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num( device ) - 2))
         + address_offset) ) {
       DEBUG("block start does not match addr, reset req\n");
       reset_address_flag = 1;
@@ -674,7 +674,7 @@ int32_t stm32_get_commands( dfu_device_t *device ) {
     return UNSPECIFIED_ERROR;
   }
 
-  dfu_set_transaction_num( 0 );
+  dfu_set_transaction_num( device, 0 );
   result = dfu_upload( device, xfer_len, buffer );
   if( result < 0) {
     dfu_status_t status;


### PR DESCRIPTION
This moves all global variables (except `debug`) to be members of the `dfu_device_t` struct. This is critical for thread safety in case multiple instances of the (to be finished) libdfu library are used concurrently from different threads.