### PR TITLE
Use clang-format to keep code consistently formatted

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: GNU
+AllowShortBlocksOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: Yes
+AllowShortIfStatementsOnASingleLine: true
+AlignConsecutiveMacros: true
+ColumnLimit: 120
+IndentWidth: 4
+BreakBeforeBraces: Attach

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,25 @@
+name: Check code quality
+
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  format:
+    name: Check formatting with clang-format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check formatting of all source files
+        run: clang-format -i src/*.h src/*.c
+
+      - name: Check for uncommitted changes (fail if there are any)
+        run: |
+          git diff --exit-code
+          git diff --cached --exit-code

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -93,6 +93,7 @@ struct target_mapping_structure {
 
 /* ----- target specific structures ----------------------------------------- */
 static struct target_mapping_structure target_map[] = {
+    // clang-format off
     // START_TARGET_LIST_LINE .. used for autocompletion script
     // Name             ID (arguments.h)    DevType    PID     VID     MemSize  BootSz  BootLoc  FPage EPage  ESize
     { "at89c51snd1c",   tar_at89c51snd1c,   ADC_8051,  0x2FFF, 0x03eb, 0x10000, 0x1000, BL_TOP,    128,   0,      0 },
@@ -187,10 +188,12 @@ static struct target_mapping_structure target_map[] = {
     { "stm32f4_G",      tar_stm32f4_G,      DC_STM32,  0xdf11, 0x0483, 0x100000,0x0000, BL_EXTRA,  512,   0,      0 },
     { NULL }
     // END_TARGET_LIST_LINE .. used for autocompletion script
+    // clang-format on
 };
 
 /* ----- command specific structures ---------------------------------------- */
 static struct option_mapping_structure command_map[] = {
+    // clang-format off
     { "configure",    com_configure },
     { "read",         com_read      },
     { "dump",         com_dump      },
@@ -210,20 +213,24 @@ static struct option_mapping_structure command_map[] = {
     { "bin2hex",      com_bin2hex   },
     { "hex2bin",      com_hex2bin   },
     { NULL }
+    // clang-format on
 };
 
 /* ----- configure specific structures -------------------------------------- */
 static struct option_mapping_structure configure_map[] = {
+    // clang-format off
     { "BSB", conf_BSB },
     { "SBV", conf_SBV },
     { "SSB", conf_SSB },
     { "EB",  conf_EB  },
     { "HSB", conf_HSB },
     { NULL }
+    // clang-format on
 };
 
 /* ----- get specific structures -------------------------------------- */
 static struct option_mapping_structure get_map[] = {
+    // clang-format off
     { "bootloader-version", get_bootloader   },
     { "ID1",                get_ID1          },
     { "ID2",                get_ID2          },
@@ -237,10 +244,12 @@ static struct option_mapping_structure get_map[] = {
     { "product-revision",   get_product_rev  },
     { "HSB",                get_HSB          },
     { NULL }
+    // clang-format on
 };
 
 /* ----- getfuse specific structures ---------------------------------- */
 static struct option_mapping_structure getfuse_map[] = {
+    // clang-format off
     { "LOCK",           get_lock           },
     { "EPFL",           get_epfl           },
     { "BOOTPROT",       get_bootprot       },
@@ -251,10 +260,12 @@ static struct option_mapping_structure getfuse_map[] = {
     { "ISP_IO_COND_EN", get_isp_io_cond_en },
     { "ISP_FORCE",      get_isp_force      },
     { NULL }
+    // clang-format on
 };
 
 /* ----- setfuse specific structures ---------------------------------- */
 static struct option_mapping_structure setfuse_map[] = {
+    // clang-format off
     { "LOCK",           set_lock           },
     { "EPFL",           set_epfl           },
     { "BOOTPROT",       set_bootprot       },
@@ -265,6 +276,7 @@ static struct option_mapping_structure setfuse_map[] = {
     { "ISP_IO_COND_EN", set_isp_io_cond_en },
     { "ISP_FORCE",      set_isp_force      },
     { NULL }
+    // clang-format on
 };
 
 static void list_targets(int mode)

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -18,22 +18,22 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 
-#include "dfu-device.h"
-#include "config.h"
 #include "arguments.h"
+#include "config.h"
+#include "dfu-device.h"
 #include "util.h"
 
 // Modes used to display the list of targets.
-#define LIST_STD        0
-#define LIST_TEX        1
-#define LIST_HTML       2
+#define LIST_STD  0
+#define LIST_TEX  1
+#define LIST_HTML 2
 
 /* Bootloader location options
    For AVR32 the bootloader is at the bottom of memory space and is included
@@ -47,16 +47,16 @@
    it is not obvious how the addressing would work and none of the Atmel
    chips do this at present.
 */
-#define BL_BASE         0   /* Bootloader at bottom */
-#define BL_TOP          1   /* Bootloader at top, space included in total memory */
-#define BL_EXTRA        2   /* Bootloader at top in separate memory area */
-#define BL_SPECIFIC     3   /* Any value greater than this is a specific start address */
+#define BL_BASE     0 /* Bootloader at bottom */
+#define BL_TOP      1 /* Bootloader at top, space included in total memory */
+#define BL_EXTRA    2 /* Bootloader at top in separate memory area */
+#define BL_SPECIFIC 3 /* Any value greater than this is a specific start address */
 
-extern int debug;       /* defined in main.c */
+extern int debug; /* defined in main.c */
 
 #define ARGUMENTS_DEBUG_THRESHOLD 100
 
-#define DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, ARGUMENTS_DEBUG_THRESHOLD, __VA_ARGS__ )
+#define DEBUG(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, ARGUMENTS_DEBUG_THRESHOLD, __VA_ARGS__)
 
 struct option_mapping_structure {
     const char *name;
@@ -279,8 +279,8 @@ static struct option_mapping_structure setfuse_map[] = {
     // clang-format on
 };
 
-static void list_targets(int mode)
-{
+static void
+list_targets (int mode) {
     struct target_mapping_structure *map = NULL;
     int col = 0;
     int group_count = 0;
@@ -289,133 +289,116 @@ static void list_targets(int mode)
 
     map = target_map;
 
-    while( 0 != *((int32_t *) map) ) {
-        if( device_type != map->device_type ) {
+    while (0 != *((int32_t *)map)) {
+        if (device_type != map->device_type) {
             device_type = map->device_type;
-            switch( device_type ) {
-            case ADC_8051:  dev_type_name = "8051";  break;
-            case ADC_AVR:   dev_type_name = "AVR";   break;
+            switch (device_type) {
+            case ADC_8051: dev_type_name = "8051"; break;
+            case ADC_AVR: dev_type_name = "AVR"; break;
             case ADC_AVR32: dev_type_name = "AVR32"; break;
             case ADC_XMEGA: dev_type_name = "XMEGA"; break;
-            case DC_STM32:  dev_type_name = "STM32F4"; break;
-            default:        dev_type_name = NULL;    break;
+            case DC_STM32: dev_type_name = "STM32F4"; break;
+            default: dev_type_name = NULL; break;
             }
-            if( dev_type_name != NULL ) {
-                if( LIST_TEX == mode ) {
-                    if( map != target_map )
-                        fprintf( stdout, "\n" );
-                    fprintf( stdout, ".IP \"%s based controllers:\"\n", dev_type_name );
-                } else if( LIST_HTML == mode ) {
-                    if( map != target_map )
-                        fprintf( stdout, "\n</p>\n" );
-                    fprintf( stdout, "<h3>%s based controllers:</h3>\n<p>\n", dev_type_name );
+            if (dev_type_name != NULL) {
+                if (LIST_TEX == mode) {
+                    if (map != target_map) fprintf (stdout, "\n");
+                    fprintf (stdout, ".IP \"%s based controllers:\"\n", dev_type_name);
+                } else if (LIST_HTML == mode) {
+                    if (map != target_map) fprintf (stdout, "\n</p>\n");
+                    fprintf (stdout, "<h3>%s based controllers:</h3>\n<p>\n", dev_type_name);
                 } else {
-                    if( 0 != col )
-                        fprintf( stdout, "\n" );
-                    fprintf( stdout, "%s based controllers:\n", dev_type_name );
+                    if (0 != col) fprintf (stdout, "\n");
+                    fprintf (stdout, "%s based controllers:\n", dev_type_name);
                 }
                 group_count = 0;
                 col = 0;
             }
         }
-        if( LIST_STD == mode ) {
-            if( 0 == col ) {
-                fprintf( stdout, " " );
-            }
-            fprintf( stdout, "   %-16s", map->name );
-            if( 4 == ++col ) {
-                fprintf( stdout, "\n" );
+        if (LIST_STD == mode) {
+            if (0 == col) { fprintf (stdout, " "); }
+            fprintf (stdout, "   %-16s", map->name);
+            if (4 == ++col) {
+                fprintf (stdout, "\n");
                 col = 0;
             }
         } else {
-            if( 0 == col ) {
-                if( 0 != group_count )
-                    fprintf( stdout, ",\n" );
+            if (0 == col) {
+                if (0 != group_count) fprintf (stdout, ",\n");
             } else {
-                fprintf( stdout, ", " );
+                fprintf (stdout, ", ");
             }
-            fprintf( stdout, "%s", map->name );
-            if( 4 == ++col ) {
-                col = 0;
-            }
+            fprintf (stdout, "%s", map->name);
+            if (4 == ++col) { col = 0; }
         }
         map++;
         group_count++;
     }
-    if( 0 != col )
-        fprintf( stdout, "\n" );
-    if( LIST_HTML == mode )
-        fprintf( stdout, "</p>\n" );
+    if (0 != col) fprintf (stdout, "\n");
+    if (LIST_HTML == mode) fprintf (stdout, "</p>\n");
 }
 
-static void basic_help()
-{
-    fprintf( stderr, PACKAGE_STRING "\n");
-    fprintf( stderr, PACKAGE_URL "\n" );
-    fprintf( stderr, "Type 'dfu-programmer --help'    for a list of commands\n" );
-    fprintf( stderr, "     'dfu-programmer --targets' to list supported target devices\n" );
+static void
+basic_help () {
+    fprintf (stderr, PACKAGE_STRING "\n");
+    fprintf (stderr, PACKAGE_URL "\n");
+    fprintf (stderr, "Type 'dfu-programmer --help'    for a list of commands\n");
+    fprintf (stderr, "     'dfu-programmer --targets' to list supported target devices\n");
 }
 
-static void usage()
-{
-    fprintf( stderr, PACKAGE_STRING "\n");
-    fprintf( stderr, PACKAGE_URL "\n" );
-    fprintf( stderr, "Usage: dfu-programmer target[:usb-bus,usb-addr] command [options] "
-                     "[global-options] [file|data]\n\n" );
-    fprintf( stderr, "global-options:\n"
+static void
+usage () {
+    fprintf (stderr, PACKAGE_STRING "\n");
+    fprintf (stderr, PACKAGE_URL "\n");
+    fprintf (stderr, "Usage: dfu-programmer target[:usb-bus,usb-addr] command [options] "
+                     "[global-options] [file|data]\n\n");
+    fprintf (stderr, "global-options:\n"
                      "        --quiet\n"
                      "        --debug level    (level is an integer specifying level of detail)\n"
                      "        Global options can be used with any command and must come\n"
-                     "        after the command and before any file or data value\n" );
-    fprintf( stderr, "\n" );
-    fprintf( stderr, "command summary:\n" );
-    fprintf( stderr, "        launch       [--no-reset]\n" );
-    fprintf( stderr, "        read         [--force] [--bin] [(flash)|--user|--eeprom]\n" );
-    fprintf( stderr, "        erase        [--force] [--suppress-validation]\n" );
-    fprintf( stderr, "        flash        [--force] [(flash)|--user|--eeprom]\n"
+                     "        after the command and before any file or data value\n");
+    fprintf (stderr, "\n");
+    fprintf (stderr, "command summary:\n");
+    fprintf (stderr, "        launch       [--no-reset]\n");
+    fprintf (stderr, "        read         [--force] [--bin] [(flash)|--user|--eeprom]\n");
+    fprintf (stderr, "        erase        [--force] [--suppress-validation]\n");
+    fprintf (stderr, "        flash        [--force] [(flash)|--user|--eeprom]\n"
                      "                     [--suppress-validation]\n"
                      "                     [--suppress-bootloader-mem]\n"
                      "                     [--validate-first]\n"
                      "                     [--ignore-outside]\n"
-                     "                     [--serial=hexdigits:offset] {file|STDIN}\n" );
-    fprintf( stderr, "        setsecure\n" );
-    fprintf( stderr, "        configure {BSB|SBV|SSB|EB|HSB}"
-                     " [--suppress-validation] data\n" );
-    fprintf( stderr, "        get     {bootloader-version|ID1|ID2|BSB|SBV|SSB|EB|\n"
+                     "                     [--serial=hexdigits:offset] {file|STDIN}\n");
+    fprintf (stderr, "        setsecure\n");
+    fprintf (stderr, "        configure {BSB|SBV|SSB|EB|HSB}"
+                     " [--suppress-validation] data\n");
+    fprintf (stderr, "        get     {bootloader-version|ID1|ID2|BSB|SBV|SSB|EB|\n"
                      "                 manufacturer|family|product-name|\n"
-                     "                 product-revision|HSB}\n" );
-    fprintf( stderr, "        getfuse {LOCK|EPFL|BOOTPROT|BODLEVEL|BODHYST|\n"
+                     "                 product-revision|HSB}\n");
+    fprintf (stderr, "        getfuse {LOCK|EPFL|BOOTPROT|BODLEVEL|BODHYST|\n"
                      "                 BODEN|ISP_BOD_EN|ISP_IO_COND_EN|\n"
-                     "                 ISP_FORCE}\n" );
-    fprintf( stderr, "        setfuse {LOCK|EPFL|BOOTPROT|BODLEVEL|BODHYST|\n"
+                     "                 ISP_FORCE}\n");
+    fprintf (stderr, "        setfuse {LOCK|EPFL|BOOTPROT|BODLEVEL|BODHYST|\n"
                      "                 BODEN|ISP_BOD_EN|ISP_IO_COND_EN|\n"
-                     "                 ISP_FORCE} data\n" );
-    fprintf( stderr, "\n" );
-    fprintf( stderr, "additional details:\n" );
-    fprintf( stderr,
-" launch: Launch from the bootloader into the main program using a watchdog\n"
-"         reset.  To jump directly into the main program use --no-reset.\n");
-    fprintf( stderr,
-"   read: Read the program memory in flash and output non-blank pages in ihex\n"
-"         format.  Use --force to output the entire memory and --bin for binary\n"
-"         output.  User page and eeprom are selected using --user and --eeprom\n");
-    fprintf( stderr,
-"  erase: Erase memory contents if the chip is not blank or always with --force\n");
-    fprintf( stderr,
-"  flash: Flash a program onto device flash memory.  EEPROM and user page are\n"
-"         selected using --eeprom|--user flags. Use --force to ignore warning\n"
-"         when data exists in target memory region.  Bootloader configuration\n"
-"         uses last 4 to 8 bytes of user page, --force always required here.\n");
-    fprintf( stderr, "Note: version 0.6.1 commands still supported.\n");
+                     "                 ISP_FORCE} data\n");
+    fprintf (stderr, "\n");
+    fprintf (stderr, "additional details:\n");
+    fprintf (stderr, " launch: Launch from the bootloader into the main program using a watchdog\n"
+                     "         reset.  To jump directly into the main program use --no-reset.\n");
+    fprintf (stderr, "   read: Read the program memory in flash and output non-blank pages in ihex\n"
+                     "         format.  Use --force to output the entire memory and --bin for binary\n"
+                     "         output.  User page and eeprom are selected using --user and --eeprom\n");
+    fprintf (stderr, "  erase: Erase memory contents if the chip is not blank or always with --force\n");
+    fprintf (stderr, "  flash: Flash a program onto device flash memory.  EEPROM and user page are\n"
+                     "         selected using --eeprom|--user flags. Use --force to ignore warning\n"
+                     "         when data exists in target memory region.  Bootloader configuration\n"
+                     "         uses last 4 to 8 bytes of user page, --force always required here.\n");
+    fprintf (stderr, "Note: version 0.6.1 commands still supported.\n");
 }
 
-
-static int32_t assign_option( int32_t *arg,
-                              char *value,
-                              struct option_mapping_structure *map )
-{
-    while( 0 != *((int32_t *) map) ) {
-        if( 0 == strcasecmp(value, map->name) ) {
+static int32_t
+assign_option (int32_t *arg, char *value, struct option_mapping_structure *map) {
+    while (0 != *((int32_t *)map)) {
+        if (0 == strcasecmp (value, map->name)) {
             *arg = map->value;
             return 0;
         }
@@ -426,41 +409,36 @@ static int32_t assign_option( int32_t *arg,
     return -1;
 }
 
-static int32_t assign_target( struct programmer_arguments *args,
-                              char *value,
-                              struct target_mapping_structure *map )
-{
-    while( 0 != *((int32_t *) map) ) {
-        size_t name_len = strlen(map->name);
-        if( 0 == strncasecmp(value, map->name, name_len)
-            && (value[name_len] == '\0'
-                || value[name_len] == ':')) {
-            args->target  = map->value;
+static int32_t
+assign_target (struct programmer_arguments *args, char *value, struct target_mapping_structure *map) {
+    while (0 != *((int32_t *)map)) {
+        size_t name_len = strlen (map->name);
+        if (0 == strncasecmp (value, map->name, name_len) && (value[name_len] == '\0' || value[name_len] == ':')) {
+            args->target = map->value;
             args->chip_id = map->chip_id;
             args->vendor_id = map->vendor_id;
             args->bus_id = 0;
             args->device_address = 0;
             if (value[name_len] == ':') {
-              /* The target name includes USB bus and address info.
-               * This is used to differentiate between multiple dfu
-               * devices with the same vendor/chip ID numbers. By
-               * specifying the bus and address, multiple units can
-               * be programmed at one time.
-               */
-              int bus = 0;
-              int address = 0;
-              if( 2 != sscanf(&value[name_len+1], "%i,%i", &bus, &address) )
-                return -1;
-              if (bus <= 0) return -1;
-              if (address < 0) return -1;
-              args->bus_id = bus;
-              args->device_address = address;
+                /* The target name includes USB bus and address info.
+                 * This is used to differentiate between multiple dfu
+                 * devices with the same vendor/chip ID numbers. By
+                 * specifying the bus and address, multiple units can
+                 * be programmed at one time.
+                 */
+                int bus = 0;
+                int address = 0;
+                if (2 != sscanf (&value[name_len + 1], "%i,%i", &bus, &address)) return -1;
+                if (bus <= 0) return -1;
+                if (address < 0) return -1;
+                args->bus_id = bus;
+                args->device_address = address;
             }
             args->device_type = map->device_type;
             args->eeprom_memory_size = map->eeprom_memory_size;
             args->flash_page_size = map->flash_page_size;
             args->eeprom_page_size = map->eeprom_page_size;
-            if ( map->bootloader_location > BL_SPECIFIC ) {
+            if (map->bootloader_location > BL_SPECIFIC) {
                 /* Bootloader space at a specific location, but does not
                    lie immediately above the application flash area.
                 */
@@ -470,7 +448,7 @@ static int32_t assign_target( struct programmer_arguments *args,
                 args->bootloader_top = map->bootloader_location + map->bootloader_size - 1;
                 args->memory_address_bottom = args->flash_address_bottom;
                 args->memory_address_top = args->bootloader_top;
-            } else if( BL_BASE == map->bootloader_location ) {
+            } else if (BL_BASE == map->bootloader_location) {
                 /* Bootloader space is at bottom of memory and is
                    included within stated memory space. */
                 args->bootloader_bottom = 0;
@@ -481,7 +459,7 @@ static int32_t assign_target( struct programmer_arguments *args,
                 args->memory_address_top = args->flash_address_top;
             } else {
                 /* Bootloader space is at top of memory above application area. */
-                if( BL_EXTRA == map->bootloader_location ) {
+                if (BL_EXTRA == map->bootloader_location) {
                     /* Bootloader space is additional to stated memory space. */
                     args->bootloader_bottom = map->memory_size;
                 } else {
@@ -495,40 +473,32 @@ static int32_t assign_target( struct programmer_arguments *args,
                 args->memory_address_top = args->bootloader_top;
             }
 
-            switch( args->device_type ) {
-                case ADC_8051:
-                    strncpy( args->device_type_string, "8051",
-                             DEVICE_TYPE_STRING_MAX_LENGTH );
-                    args->initial_abort = false;
-                    //args->honor_interfaceclass = true;
-                    break;
-                case ADC_AVR:
-                    strncpy( args->device_type_string, "AVR",
-                             DEVICE_TYPE_STRING_MAX_LENGTH );
-                    args->initial_abort = true;
-                    //args->honor_interfaceclass = false;
-                    break;
-                case ADC_AVR32:
-                    strncpy( args->device_type_string, "AVR32",
-                             DEVICE_TYPE_STRING_MAX_LENGTH );
-                    args->initial_abort = false;
-                    //args->honor_interfaceclass = true;
-                    break;
-                case ADC_XMEGA:
-                    strncpy( args->device_type_string, "XMEGA",
-                             DEVICE_TYPE_STRING_MAX_LENGTH );
-                    args->initial_abort = true;
-                    //args->honor_interfaceclass = false;
-                    break;
-                case DC_STM32:
-                    strncpy( args->device_type_string, "STM32",
-                             DEVICE_TYPE_STRING_MAX_LENGTH );
-                    break;
-                default :
+            switch (args->device_type) {
+            case ADC_8051:
+                strncpy (args->device_type_string, "8051", DEVICE_TYPE_STRING_MAX_LENGTH);
+                args->initial_abort = false;
+                // args->honor_interfaceclass = true;
+                break;
+            case ADC_AVR:
+                strncpy (args->device_type_string, "AVR", DEVICE_TYPE_STRING_MAX_LENGTH);
+                args->initial_abort = true;
+                // args->honor_interfaceclass = false;
+                break;
+            case ADC_AVR32:
+                strncpy (args->device_type_string, "AVR32", DEVICE_TYPE_STRING_MAX_LENGTH);
+                args->initial_abort = false;
+                // args->honor_interfaceclass = true;
+                break;
+            case ADC_XMEGA:
+                strncpy (args->device_type_string, "XMEGA", DEVICE_TYPE_STRING_MAX_LENGTH);
+                args->initial_abort = true;
+                // args->honor_interfaceclass = false;
+                break;
+            case DC_STM32: strncpy (args->device_type_string, "STM32", DEVICE_TYPE_STRING_MAX_LENGTH); break;
+            default:
                 // cSpell:words UNKNO
-                    strncpy( args->device_type_string, "UNKNO",
-                             DEVICE_TYPE_STRING_MAX_LENGTH );
-                    break;
+                strncpy (args->device_type_string, "UNKNO", DEVICE_TYPE_STRING_MAX_LENGTH);
+                break;
             }
             /* There have been several reports on the mailing list of dfu-programmer
                reporting "No device present" when there clearly is. It seems Atmel's
@@ -547,15 +517,13 @@ static int32_t assign_target( struct programmer_arguments *args,
     return -1;
 }
 
-static int32_t assign_global_options( struct programmer_arguments *args,
-                                      const size_t argc,
-                                      char **argv )
-{
+static int32_t
+assign_global_options (struct programmer_arguments *args, const size_t argc, char **argv) {
     size_t i = 0;
 
     /* Find '--quiet' if it is here */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--quiet", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--quiet", argv[i])) {
             *argv[i] = '\0';
             args->quiet = 1;
             break;
@@ -563,8 +531,8 @@ static int32_t assign_global_options( struct programmer_arguments *args,
     }
 
     /* Find '--suppress-bootloader-mem' if it is here */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--suppress-bootloader-mem", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--suppress-bootloader-mem", argv[i])) {
             *argv[i] = '\0';
             args->suppressBootloader = 1;
             break;
@@ -573,25 +541,19 @@ static int32_t assign_global_options( struct programmer_arguments *args,
 
     /* Find '--suppress-validation' if it is here - even though it is not
      * used by all this is easier. */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--suppress-validation", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--suppress-validation", argv[i])) {
             *argv[i] = '\0';
 
-            switch( args->command ) {
-                case com_configure:
-                    args->com_configure_data.suppress_validation = 1;
-                    break;
-                case com_erase:
-                    args->com_erase_data.suppress_validation = 1;
-                    break;
-                case com_flash:
-                case com_eflash:
-                case com_user:
-                    args->com_flash_data.suppress_validation = 1;
-                    break;
-                default:
-                    /* not supported. */
-                    return -1;
+            switch (args->command) {
+            case com_configure: args->com_configure_data.suppress_validation = 1; break;
+            case com_erase: args->com_erase_data.suppress_validation = 1; break;
+            case com_flash:
+            case com_eflash:
+            case com_user: args->com_flash_data.suppress_validation = 1; break;
+            default:
+                /* not supported. */
+                return -1;
             }
             break;
         }
@@ -599,19 +561,17 @@ static int32_t assign_global_options( struct programmer_arguments *args,
 
     /* Find '--validate-first' if it is here - even though it is not
      * used by all this is easier. */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--validate-first", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--validate-first", argv[i])) {
             *argv[i] = '\0';
 
-            switch( args->command ) {
-                case com_flash:
-                case com_eflash:
-                case com_user:
-                    args->com_flash_data.validate_first = 1;
-                    break;
-                default:
-                    /* not supported. */
-                    return -1;
+            switch (args->command) {
+            case com_flash:
+            case com_eflash:
+            case com_user: args->com_flash_data.validate_first = 1; break;
+            default:
+                /* not supported. */
+                return -1;
             }
             break;
         }
@@ -619,87 +579,71 @@ static int32_t assign_global_options( struct programmer_arguments *args,
 
     /* Find '--ignore-outside' if it is here - even though it is not
      * used by all this is easier. */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--ignore-outside", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--ignore-outside", argv[i])) {
             *argv[i] = '\0';
 
-            switch( args->command ) {
-                case com_flash:
-                case com_eflash:
-                case com_user:
-                    args->com_flash_data.ignore_outside = 1;
-                    break;
-                default:
-                    /* not supported. */
-                    return -1;
+            switch (args->command) {
+            case com_flash:
+            case com_eflash:
+            case com_user: args->com_flash_data.ignore_outside = 1; break;
+            default:
+                /* not supported. */
+                return -1;
             }
             break;
         }
     }
 
     /* Find '--bin' for read binary */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--bin", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--bin", argv[i])) {
             *argv[i] = '\0';
 
-            switch( args->command ) {
-                case com_read:
-                case com_dump:
-                case com_edump:
-                case com_udump:
-                    args->com_read_data.bin = 1;
-                    break;
-                default:
-                    /* not supported. */
-                    return -1;
+            switch (args->command) {
+            case com_read:
+            case com_dump:
+            case com_edump:
+            case com_udump: args->com_read_data.bin = 1; break;
+            default:
+                /* not supported. */
+                return -1;
             }
             break;
         }
     }
 
     /* Find '--user' for the user page segment */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--user", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--user", argv[i])) {
             *argv[i] = '\0';
-            switch( args->command ) {
-                case com_read:
-                case com_udump:
-                    args->com_read_data.segment = mem_user;
-                    break;
-                case com_flash:
-                case com_user:
-                    args->com_flash_data.segment = mem_user;
-                    break;
-                case com_bin2hex:
-                    args->com_convert_data.segment = mem_user;
-                    break;
-                default:
-                    /* not supported. */
-                    return -1;
+            switch (args->command) {
+            case com_read:
+            case com_udump: args->com_read_data.segment = mem_user; break;
+            case com_flash:
+            case com_user: args->com_flash_data.segment = mem_user; break;
+            case com_bin2hex: args->com_convert_data.segment = mem_user; break;
+            default:
+                /* not supported. */
+                return -1;
             }
             break;
         }
     }
 
     /* Find '--eeprom' for the eeprom page segment */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--eeprom", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--eeprom", argv[i])) {
             *argv[i] = '\0';
-            switch( args->command ) {
-                case com_read:
-                case com_udump:
-                    args->com_read_data.segment = mem_eeprom;
-                    break;
-                case com_flash:
-                case com_user:
-                    args->com_flash_data.segment = mem_eeprom;
-                    break;
-                case com_bin2hex:
-                    args->com_convert_data.segment = mem_eeprom;
-                    break;
-                default:
-                    /* not supported. */
-                    return -1;
+            switch (args->command) {
+            case com_read:
+            case com_udump: args->com_read_data.segment = mem_eeprom; break;
+            case com_flash:
+            case com_user: args->com_flash_data.segment = mem_eeprom; break;
+            case com_bin2hex: args->com_convert_data.segment = mem_eeprom; break;
+            default:
+                /* not supported. */
+                return -1;
             }
             break;
         }
@@ -707,24 +651,18 @@ static int32_t assign_global_options( struct programmer_arguments *args,
 
     /* Find '--force' if it is here - even though it is not
      * used by all this is easier. */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--force", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--force", argv[i])) {
             *argv[i] = '\0';
-            switch( args->command ) {
-                case com_flash :
-                case com_eflash :
-                case com_user :
-                    args->com_flash_data.force = true;
-                    break;
-                case com_read :
-                    args->com_read_data.force = true;
-                    break;
-                case com_erase :
-                    args->com_erase_data.force = true;
-                    break;
-                default:
-                    // not supported
-                    return -1;
+            switch (args->command) {
+            case com_flash:
+            case com_eflash:
+            case com_user: args->com_flash_data.force = true; break;
+            case com_read: args->com_read_data.force = true; break;
+            case com_erase: args->com_erase_data.force = true; break;
+            default:
+                // not supported
+                return -1;
             }
             break;
         }
@@ -732,11 +670,11 @@ static int32_t assign_global_options( struct programmer_arguments *args,
 
     /* Find '--no-reset' if it is here - even though it is not
      * used by all this is easier. */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strcmp("--no-reset", argv[i]) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strcmp ("--no-reset", argv[i])) {
             *argv[i] = '\0';
 
-            if ( args->command == com_launch ) {
+            if (args->command == com_launch) {
                 args->com_launch_config.noreset = true;
             } else {
                 // not supported
@@ -747,20 +685,17 @@ static int32_t assign_global_options( struct programmer_arguments *args,
     }
 
     /* Find '--debug' if it is here */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strncmp("--debug", argv[i], 7) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strncmp ("--debug", argv[i], 7)) {
 
-            if( 0 == strncmp("--debug=", argv[i], 8) ) {
-                if( 1 != sscanf(argv[i], "--debug=%i", &debug) )
-                    return -2;
+            if (0 == strncmp ("--debug=", argv[i], 8)) {
+                if (1 != sscanf (argv[i], "--debug=%i", &debug)) return -2;
             } else {
-                if( (i+1) >= argc )
-                    return -3;
+                if ((i + 1) >= argc) return -3;
 
-                if( 1 != sscanf(argv[i+1], "%i", &debug) )
-                    return -4;
+                if (1 != sscanf (argv[i + 1], "%i", &debug)) return -4;
 
-                *argv[i+1] = '\0';
+                *argv[i + 1] = '\0';
             }
             *argv[i] = '\0';
             break;
@@ -768,67 +703,65 @@ static int32_t assign_global_options( struct programmer_arguments *args,
     }
 
     /* Find '--serial=<hexdigit+>:<offset>' */
-    for( i = 0; i < argc; i++ ) {
-        if( 0 == strncmp("--serial=", argv[i], 9) ) {
+    for (i = 0; i < argc; i++) {
+        if (0 == strncmp ("--serial=", argv[i], 9)) {
             *argv[i] = '\0';
 
-            switch( args->command ) {
-                case com_flash:
-                case com_eflash:
-                case com_user: {
-                    char *hexdigits = &argv[i][9];
-                    char *offset_start = hexdigits;
-                    size_t num_digits = 0;
-                    int16_t *serial_data = NULL;
-                    long serial_offset = 0;
-                    size_t j = 0;
-                    char buffer[3] = {0,0,0};
-                    while (*offset_start != ':') {
-                        char c = *offset_start;
-                        if ('\0' == c) {
-                            return -1;
-                        } else if (('0' <= c && c <= '9')
-                            || ('a' <= c && c <= 'f')
-                            || ('A' <= c && c <= 'F')) {
-                            ++offset_start;
-                        } else {
-                          fprintf(stderr, "other character: '%c'\n", *offset_start);
-                            return -1;
-                        }
-                    }
-                    num_digits = offset_start - hexdigits;
-                    if (num_digits & 1) {
-                        fprintf(stderr,"There must be an even number of hexdigits in the serial data\n");
+            switch (args->command) {
+            case com_flash:
+            case com_eflash:
+            case com_user: {
+                char *hexdigits = &argv[i][9];
+                char *offset_start = hexdigits;
+                size_t num_digits = 0;
+                int16_t *serial_data = NULL;
+                long serial_offset = 0;
+                size_t j = 0;
+                char buffer[3] = { 0, 0, 0 };
+                while (*offset_start != ':') {
+                    char c = *offset_start;
+                    if ('\0' == c) {
+                        return -1;
+                    } else if (('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')) {
+                        ++offset_start;
+                    } else {
+                        fprintf (stderr, "other character: '%c'\n", *offset_start);
                         return -1;
                     }
-                    *offset_start++ = '\0';
-                    if( 1 != sscanf(offset_start, "%ld", &serial_offset) ) {
-                      fprintf(stderr, "sscanf failed\n");
-                      return -1;
-                    }
-                    serial_data = (int16_t *) malloc( (num_digits/2) * sizeof(int16_t) );
-                    for (j=0; j < num_digits; j+=2) {
-                      int data;
-                      buffer[0] = hexdigits[j];
-                      buffer[1] = hexdigits[j+1];
-                      buffer[2] = 0;
-                      if( 1 != sscanf(buffer, "%02x", &data) ) {
-                        fprintf(stderr, "sscanf failed with buffer: %s\n", buffer);
-                        return -1;
-                      }
-                      serial_data[j/2] = (int16_t)data;
-                    }
-                    args->com_flash_data.serial_data = serial_data;
-                    args->com_flash_data.serial_offset = serial_offset;
-                    args->com_flash_data.serial_length = num_digits/2;
-                    break;
                 }
-                default:
-                    /* not supported. */
-                  fprintf(stderr,"command did not match: %d    flash: %d\n", args->command, com_flash);
+                num_digits = offset_start - hexdigits;
+                if (num_digits & 1) {
+                    fprintf (stderr, "There must be an even number of hexdigits in the serial data\n");
                     return -1;
+                }
+                *offset_start++ = '\0';
+                if (1 != sscanf (offset_start, "%ld", &serial_offset)) {
+                    fprintf (stderr, "sscanf failed\n");
+                    return -1;
+                }
+                serial_data = (int16_t *)malloc ((num_digits / 2) * sizeof (int16_t));
+                for (j = 0; j < num_digits; j += 2) {
+                    int data;
+                    buffer[0] = hexdigits[j];
+                    buffer[1] = hexdigits[j + 1];
+                    buffer[2] = 0;
+                    if (1 != sscanf (buffer, "%02x", &data)) {
+                        fprintf (stderr, "sscanf failed with buffer: %s\n", buffer);
+                        return -1;
+                    }
+                    serial_data[j / 2] = (int16_t)data;
+                }
+                args->com_flash_data.serial_data = serial_data;
+                args->com_flash_data.serial_offset = serial_offset;
+                args->com_flash_data.serial_length = num_digits / 2;
+                break;
             }
-            fprintf(stderr, "Success getting serial number\n");
+            default:
+                /* not supported. */
+                fprintf (stderr, "command did not match: %d    flash: %d\n", args->command, com_flash);
+                return -1;
+            }
+            fprintf (stderr, "Success getting serial number\n");
             break;
         }
     }
@@ -836,27 +769,19 @@ static int32_t assign_global_options( struct programmer_arguments *args,
     return 0;
 }
 
-static int32_t assign_com_setfuse_option( struct programmer_arguments *args,
-                                            const int32_t parameter,
-                                            char *value )
-{
+static int32_t
+assign_com_setfuse_option (struct programmer_arguments *args, const int32_t parameter, char *value) {
     /* name & value */
-    if( 0 == parameter ) {
+    if (0 == parameter) {
         /* name */
-        if( 0 != assign_option((int32_t *) &(args->com_setfuse_data.name),
-                               value, setfuse_map) )
-        {
-            return -1;
-        }
+        if (0 != assign_option ((int32_t *)&(args->com_setfuse_data.name), value, setfuse_map)) { return -1; }
     } else {
         int32_t temp = 0;
         /* value */
-        if( 1 != sscanf(value, "%i", &(temp)) )
-            return -2;
+        if (1 != sscanf (value, "%i", &(temp))) return -2;
 
         /* ensure the range is greater than 0 */
-        if( temp < 0 )
-            return -3;
+        if (temp < 0) return -3;
 
         args->com_setfuse_data.value = temp;
     }
@@ -864,27 +789,19 @@ static int32_t assign_com_setfuse_option( struct programmer_arguments *args,
     return 0;
 }
 
-static int32_t assign_com_configure_option( struct programmer_arguments *args,
-                                            const int32_t parameter,
-                                            char *value )
-{
+static int32_t
+assign_com_configure_option (struct programmer_arguments *args, const int32_t parameter, char *value) {
     /* name & value */
-    if( 0 == parameter ) {
+    if (0 == parameter) {
         /* name */
-        if( 0 != assign_option((int32_t *) &(args->com_configure_data.name),
-                               value, configure_map) )
-        {
-            return -1;
-        }
+        if (0 != assign_option ((int32_t *)&(args->com_configure_data.name), value, configure_map)) { return -1; }
     } else {
         int32_t temp = 0;
         /* value */
-        if( 1 != sscanf(value, "%i", &(temp)) )
-            return -2;
+        if (1 != sscanf (value, "%i", &(temp))) return -2;
 
         /* ensure the range is greater than 0 */
-        if( temp < 0 )
-            return -3;
+        if (temp < 0) return -3;
 
         args->com_configure_data.value = temp;
     }
@@ -892,10 +809,8 @@ static int32_t assign_com_configure_option( struct programmer_arguments *args,
     return 0;
 }
 
-static int32_t assign_com_flash_option( struct programmer_arguments *args,
-                                        const int32_t parameter,
-                                        char *value )
-{
+static int32_t
+assign_com_flash_option (struct programmer_arguments *args, const int32_t parameter, char *value) {
     /* file */
     args->com_flash_data.original_first_char = *value;
     args->com_flash_data.file = value;
@@ -903,10 +818,8 @@ static int32_t assign_com_flash_option( struct programmer_arguments *args,
     return 0;
 }
 
-static int32_t assign_com_convert_option( struct programmer_arguments *args,
-                                          const int32_t parameter,
-                                          char *value )
-{
+static int32_t
+assign_com_convert_option (struct programmer_arguments *args, const int32_t parameter, char *value) {
     /* file */
     args->com_convert_data.original_first_char = *value;
     args->com_convert_data.file = value;
@@ -914,348 +827,304 @@ static int32_t assign_com_convert_option( struct programmer_arguments *args,
     return 0;
 }
 
-
-static int32_t assign_com_getfuse_option( struct programmer_arguments *args,
-                                      const int32_t parameter,
-                                      char *value )
-{
+static int32_t
+assign_com_getfuse_option (struct programmer_arguments *args, const int32_t parameter, char *value) {
     /* name */
-    if( 0 != assign_option((int32_t *) &(args->com_getfuse_data.name),
-                           value, getfuse_map) )
-    {
-        return -1;
-    }
+    if (0 != assign_option ((int32_t *)&(args->com_getfuse_data.name), value, getfuse_map)) { return -1; }
 
     return 0;
 }
 
-static int32_t assign_com_get_option( struct programmer_arguments *args,
-                                      const int32_t parameter,
-                                      char *value )
-{
+static int32_t
+assign_com_get_option (struct programmer_arguments *args, const int32_t parameter, char *value) {
     /* name */
-    if( 0 != assign_option((int32_t *) &(args->com_get_data.name),
-                           value, get_map) )
-    {
-        return -1;
-    }
+    if (0 != assign_option ((int32_t *)&(args->com_get_data.name), value, get_map)) { return -1; }
 
     return 0;
 }
 
-static int32_t assign_command_options( struct programmer_arguments *args,
-                                       const size_t argc,
-                                       char **argv )
-{
+static int32_t
+assign_command_options (struct programmer_arguments *args, const size_t argc, char **argv) {
     size_t i = 0;
     int32_t param = 0;
     int32_t required_params = 0;
 
     /* Deal with all remaining command-specific arguments. */
-    for( i = 0; i < argc; i++ ) {
-        if( '\0' == *argv[i] )
-            continue;
+    for (i = 0; i < argc; i++) {
+        if ('\0' == *argv[i]) continue;
 
-        switch( args->command ) {
-            case com_configure:
-                required_params = 2;
-                if( 0 != assign_com_configure_option(args, param, argv[i]) )
-                    return -1;
-                break;
+        switch (args->command) {
+        case com_configure:
+            required_params = 2;
+            if (0 != assign_com_configure_option (args, param, argv[i])) return -1;
+            break;
 
-            case com_setfuse:
-                required_params = 2;
-                if( 0 != assign_com_setfuse_option(args, param, argv[i]) )
-                    return -1;
-                break;
+        case com_setfuse:
+            required_params = 2;
+            if (0 != assign_com_setfuse_option (args, param, argv[i])) return -1;
+            break;
 
-            case com_flash:
-            case com_eflash:
-            case com_user:
-                required_params = 1;
-                if( 0 != assign_com_flash_option(args, param, argv[i]) )
-                    return -3;
-                break;
+        case com_flash:
+        case com_eflash:
+        case com_user:
+            required_params = 1;
+            if (0 != assign_com_flash_option (args, param, argv[i])) return -3;
+            break;
 
-            case com_bin2hex:
-            case com_hex2bin:
-                required_params = 1;
-                if( 0 != assign_com_convert_option(args, param, argv[i]) )
-                    return -3;
-                break;
+        case com_bin2hex:
+        case com_hex2bin:
+            required_params = 1;
+            if (0 != assign_com_convert_option (args, param, argv[i])) return -3;
+            break;
 
-            case com_getfuse:
-                required_params = 1;
-                if( 0 != assign_com_getfuse_option(args, param, argv[i]) )
-                    return -4;
-                break;
+        case com_getfuse:
+            required_params = 1;
+            if (0 != assign_com_getfuse_option (args, param, argv[i])) return -4;
+            break;
 
-            case com_get:
-                required_params = 1;
-                if( 0 != assign_com_get_option(args, param, argv[i]) )
-                    return -4;
-                break;
+        case com_get:
+            required_params = 1;
+            if (0 != assign_com_get_option (args, param, argv[i])) return -4;
+            break;
 
-            default:
-                return -5;
+        default: return -5;
         }
 
         *argv[i] = '\0';
         param++;
     }
 
-    if( required_params != param )
-        return -6;
+    if (required_params != param) return -6;
 
     return 0;
 }
 
-static void print_args( struct programmer_arguments *args )
-{
+static void
+print_args (struct programmer_arguments *args) {
     const char *command = "(unknown)";
     const char *target = "(unknown)";
     size_t i;
 
-    for( i = 0; i < sizeof(target_map) / sizeof(target_map[0]); i++ ) {
-        if( args->target == target_map[i].value ) {
+    for (i = 0; i < sizeof (target_map) / sizeof (target_map[0]); i++) {
+        if (args->target == target_map[i].value) {
             target = target_map[i].name;
             break;
         }
     }
 
-    for( i = 0; i < sizeof(command_map) / sizeof(command_map[0]); i++ ) {
-        if( args->command == command_map[i].value ) {
+    for (i = 0; i < sizeof (command_map) / sizeof (command_map[0]); i++) {
+        if (args->command == command_map[i].value) {
             command = command_map[i].name;
             break;
         }
     }
 
-    fprintf( stderr, "     target: %s\n", target );
-    fprintf( stderr, "    chip_id: 0x%04x\n", args->chip_id );
-    fprintf( stderr, "  vendor_id: 0x%04x\n", args->vendor_id );
-    fprintf( stderr, "    command: %s\n", command );
-    fprintf( stderr, "      quiet: %s\n", (0 == args->quiet) ? "false" : "true" );
-    fprintf( stderr, "      debug: %d\n", debug );
-    fprintf( stderr, "device_type: %s\n", args->device_type_string );
-    fprintf( stderr, "------ command specific below ------\n" );
+    fprintf (stderr, "     target: %s\n", target);
+    fprintf (stderr, "    chip_id: 0x%04x\n", args->chip_id);
+    fprintf (stderr, "  vendor_id: 0x%04x\n", args->vendor_id);
+    fprintf (stderr, "    command: %s\n", command);
+    fprintf (stderr, "      quiet: %s\n", (0 == args->quiet) ? "false" : "true");
+    fprintf (stderr, "      debug: %d\n", debug);
+    fprintf (stderr, "device_type: %s\n", args->device_type_string);
+    fprintf (stderr, "------ command specific below ------\n");
 
-    switch( args->command ) {
-        case com_configure:
-            fprintf( stderr, "       name: %d\n", args->com_configure_data.name );
-            fprintf( stderr, "   validate: %s\n",
-                     (args->com_configure_data.suppress_validation) ?
-                        "false" : "true" );
-            fprintf( stderr, "      value: %d\n", args->com_configure_data.value );
-            break;
-        case com_erase:
-            fprintf( stderr, "   validate: %s\n",
-                     (args->com_erase_data.suppress_validation) ?
-                        "false" : "true" );
-            break;
-        case com_flash:
-        case com_eflash:
-        case com_user:
-            fprintf( stderr, "   validate: %s\n",
-                     (args->com_flash_data.suppress_validation) ?
-                        "false" : "true" );
-            fprintf( stderr, "   hex file: %s\n", args->com_flash_data.file );
-            break;
-        case com_get:
-            fprintf( stderr, "       name: %d\n", args->com_get_data.name );
-            break;
-        case com_launch:
-            fprintf( stderr, "   no-reset: %d\n", args->com_launch_config.noreset );
-            break;
-        default:
-            break;
+    switch (args->command) {
+    case com_configure:
+        fprintf (stderr, "       name: %d\n", args->com_configure_data.name);
+        fprintf (stderr, "   validate: %s\n", (args->com_configure_data.suppress_validation) ? "false" : "true");
+        fprintf (stderr, "      value: %d\n", args->com_configure_data.value);
+        break;
+    case com_erase:
+        fprintf (stderr, "   validate: %s\n", (args->com_erase_data.suppress_validation) ? "false" : "true");
+        break;
+    case com_flash:
+    case com_eflash:
+    case com_user:
+        fprintf (stderr, "   validate: %s\n", (args->com_flash_data.suppress_validation) ? "false" : "true");
+        fprintf (stderr, "   hex file: %s\n", args->com_flash_data.file);
+        break;
+    case com_get: fprintf (stderr, "       name: %d\n", args->com_get_data.name); break;
+    case com_launch: fprintf (stderr, "   no-reset: %d\n", args->com_launch_config.noreset); break;
+    default: break;
     }
-    fprintf( stderr, "\n" );
-    fflush( stdout );
+    fprintf (stderr, "\n");
+    fflush (stdout);
 }
 
-static int32_t execute_hex2bin( struct programmer_arguments *args ) {
-    int32_t  retval = -1;
-    uint32_t  i;
+static int32_t
+execute_hex2bin (struct programmer_arguments *args) {
+    int32_t retval = -1;
+    uint32_t i;
     intel_buffer_out_t bout;
-    size_t   memory_size;
-    size_t   page_size;
+    size_t memory_size;
+    size_t page_size;
     uint32_t target_offset = 0;
 
     memory_size = args->memory_address_top + 1;
     page_size = args->flash_page_size;
 
     // ----------------- CONVERT HEX FILE TO BINARY -------------------------
-    if( 0 != intel_init_buffer_out(&bout, memory_size, page_size) ) {
-        DEBUG("ERROR initializing a buffer.\n");
+    if (0 != intel_init_buffer_out (&bout, memory_size, page_size)) {
+        DEBUG ("ERROR initializing a buffer.\n");
         goto error;
     }
 
-    if( 0!= intel_hex_to_buffer( args->com_convert_data.file, &bout,
-                target_offset, args->quiet ) ) {
-        DEBUG( "Something went wrong with creating the memory image.\n" );
+    if (0 != intel_hex_to_buffer (args->com_convert_data.file, &bout, target_offset, args->quiet)) {
+        DEBUG ("Something went wrong with creating the memory image.\n");
         goto error;
     }
 
-    if( !args->quiet )
-        fprintf( stderr, "Dumping 0x%X bytes from address offset 0x%X.\n",
-                bout.info.data_end + 1, target_offset );
-    for( i = 0; i <= bout.info.data_end; i++ ) {
-        fprintf( stdout, "%c", bout.data[i] <= 0xFF ? bout.data[i] & 0xFF : 0xFF);
+    if (!args->quiet)
+        fprintf (stderr, "Dumping 0x%X bytes from address offset 0x%X.\n", bout.info.data_end + 1, target_offset);
+    for (i = 0; i <= bout.info.data_end; i++) {
+        fprintf (stdout, "%c", bout.data[i] <= 0xFF ? bout.data[i] & 0xFF : 0xFF);
     }
 
-    fflush( stdout );
+    fflush (stdout);
 
     retval = 0;
 
 error:
-    if( NULL != bout.data ) {
-        free( bout.data );
+    if (NULL != bout.data) {
+        free (bout.data);
         bout.data = NULL;
     }
 
     return retval;
 }
 
-static int32_t execute_bin2hex( struct programmer_arguments *args ) {
-    int32_t retval = -1;        // return value for this fcn
-    intel_buffer_in_t buin;     // buffer in for storing read mem
+static int32_t
+execute_bin2hex (struct programmer_arguments *args) {
+    int32_t retval = -1;    // return value for this fcn
+    intel_buffer_in_t buin; // buffer in for storing read mem
     enum atmel_memory_unit_enum mem_segment = args->com_convert_data.segment;
     size_t mem_size = 0;
     size_t page_size = 0;
     uint32_t target_offset = 0; // address offset on the target device
-        // NOTE: target_offset may not be set appropriately for device
-        // classes other than ADC_AVR32
+                                // NOTE: target_offset may not be set appropriately for device
+                                // classes other than ADC_AVR32
     FILE *fp = NULL;
     char *filename = args->com_convert_data.file;
 
-    if( ADC_AVR32 == args->device_type ) {
-        target_offset = 0x80000000;
+    if (ADC_AVR32 == args->device_type) { target_offset = 0x80000000; }
+
+    switch (mem_segment) {
+    case mem_flash:
+        mem_size = args->memory_address_top + 1;
+        page_size = args->flash_page_size;
+        break;
+    case mem_eeprom:
+        mem_size = args->eeprom_memory_size;
+        page_size = args->eeprom_page_size;
+        break;
+    case mem_user:
+        mem_size = args->flash_page_size;
+        page_size = args->flash_page_size;
+        target_offset = 0x80800000;
+        break;
+    default: fprintf (stderr, "Dump not currently supported for this memory.\n"); goto error;
     }
 
-    switch( mem_segment ) {
-        case mem_flash:
-            mem_size = args->memory_address_top + 1;
-            page_size = args->flash_page_size;
-            break;
-        case mem_eeprom:
-            mem_size = args->eeprom_memory_size;
-            page_size = args->eeprom_page_size;
-            break;
-        case mem_user:
-            mem_size = args->flash_page_size;
-            page_size = args->flash_page_size;
-            target_offset = 0x80800000;
-            break;
-        default:
-            fprintf( stderr, "Dump not currently supported for this memory.\n" );
-            goto error;
-    }
-
-    if( 0 != intel_init_buffer_in(&buin, mem_size, page_size) ) {
-        DEBUG("ERROR initializing a buffer.\n");
+    if (0 != intel_init_buffer_in (&buin, mem_size, page_size)) {
+        DEBUG ("ERROR initializing a buffer.\n");
         goto error;
     }
 
-    if( mem_segment == mem_flash ) {
+    if (mem_segment == mem_flash) {
         buin.info.data_start = args->flash_address_bottom;
         buin.info.data_end = args->flash_address_top;
     }
 
-    if( NULL == filename ) {
-        if( !args->quiet ) fprintf( stderr, "Invalid filename.\n" );
+    if (NULL == filename) {
+        if (!args->quiet) fprintf (stderr, "Invalid filename.\n");
         retval = -2;
         goto error;
     }
 
-    if( 0 == strcmp("STDIN", filename) ) {
+    if (0 == strcmp ("STDIN", filename)) {
         fp = stdin;
     } else {
-        fp = fopen( filename, "r" );
-        if( NULL == fp ) {
-            if( !args->quiet ) fprintf( stderr, "Error opening %s\n", filename );
+        fp = fopen (filename, "r");
+        if (NULL == fp) {
+            if (!args->quiet) fprintf (stderr, "Error opening %s\n", filename);
             retval = -3;
             goto error;
         }
     }
 
-    buin.info.data_end = fread(buin.data, 1, buin.info.total_size, fp);
-    if( buin.info.data_end == 0 ) {
-        if( !args->quiet ) fprintf( stderr, "ERROR: no bytes read\n" );
+    buin.info.data_end = fread (buin.data, 1, buin.info.total_size, fp);
+    if (buin.info.data_end == 0) {
+        if (!args->quiet) fprintf (stderr, "ERROR: no bytes read\n");
         retval = -4;
         goto error;
     }
 
-    if( !args->quiet )
-        fprintf( stderr, "Read 0x%X bytes, making hex with address offset 0x%X.\n",
-                buin.info.data_end + 1, target_offset );
+    if (!args->quiet)
+        fprintf (stderr, "Read 0x%X bytes, making hex with address offset 0x%X.\n", buin.info.data_end + 1,
+                 target_offset);
 
-    retval = intel_hex_from_buffer( &buin, args->com_convert_data.force, target_offset );
+    retval = intel_hex_from_buffer (&buin, args->com_convert_data.force, target_offset);
 
 error:
-    if( NULL != buin.data ) {
-        free( buin.data );
+    if (NULL != buin.data) {
+        free (buin.data);
         buin.data = NULL;
     }
 
     return retval;
 }
 
-
-int32_t parse_arguments( struct programmer_arguments *args,
-                         const size_t argc,
-                         char **argv )
-{
+int32_t
+parse_arguments (struct programmer_arguments *args, const size_t argc, char **argv) {
     int32_t i;
     int32_t status = 0;
 
-    if( NULL == args )
-        return -1;
+    if (NULL == args) return -1;
 
     /* initialize the argument block to empty, known values */
-    args->target  = tar_none;
+    args->target = tar_none;
     args->command = com_none;
-    args->quiet   = 0;
+    args->quiet = 0;
     args->suppressBootloader = 0;
 
     /* Special case - check for the help commands which do not require a device type */
-    if( argc == 2 ) {
-        if( 0 == strcasecmp(argv[1], "--version") ) {
-            fprintf( stderr, PACKAGE_STRING "\n");
+    if (argc == 2) {
+        if (0 == strcasecmp (argv[1], "--version")) {
+            fprintf (stderr, PACKAGE_STRING "\n");
             return 1;
         }
-        if( 0 == strcasecmp(argv[1], "--targets") ) {
-            list_targets( LIST_STD );
+        if (0 == strcasecmp (argv[1], "--targets")) {
+            list_targets (LIST_STD);
             return 1;
         }
-        if( 0 == strcasecmp(argv[1], "--targets-tex") ) {
-            list_targets( LIST_TEX );
+        if (0 == strcasecmp (argv[1], "--targets-tex")) {
+            list_targets (LIST_TEX);
             return 1;
         }
-        if( 0 == strcasecmp(argv[1], "--targets-html") ) {
-            list_targets( LIST_HTML );
+        if (0 == strcasecmp (argv[1], "--targets-html")) {
+            list_targets (LIST_HTML);
             return 1;
         }
-        if( 0 == strcasecmp(argv[1], "--help") ||
-                0 == strcasecmp(argv[1], "-h") ||
-                0 == strcasecmp(argv[1], "--h") ) {
-            usage();
+        if (0 == strcasecmp (argv[1], "--help") || 0 == strcasecmp (argv[1], "-h")
+            || 0 == strcasecmp (argv[1], "--h")) {
+            usage ();
             return 1;
         }
     }
 
     /* Make sure there are the minimum arguments */
-    if( argc < 3 ) {
-        basic_help();
+    if (argc < 3) {
+        basic_help ();
         return -1;
     }
 
-    if( 0 != assign_target(args, argv[1], target_map) ) {
-        fprintf( stderr, "Unsupported target '%s'.\n", argv[1]);
+    if (0 != assign_target (args, argv[1], target_map)) {
+        fprintf (stderr, "Unsupported target '%s'.\n", argv[1]);
         status = -3;
         goto done;
     }
 
-    if( 0 != assign_option((int32_t *) &(args->command), argv[2], command_map) ) {
+    if (0 != assign_option ((int32_t *)&(args->command), argv[2], command_map)) {
         status = -4;
         goto done;
     }
@@ -1266,84 +1135,76 @@ int32_t parse_arguments( struct programmer_arguments *args,
     *argv[2] = '\0';
 
     /* assign command specific default values */
-    switch( args->command ) {
-        case com_flash :
-            args->com_flash_data.force = 0;
-            args->com_flash_data.segment = mem_flash;
-            break;
-        case com_launch :
-            args->com_launch_config.noreset = 0;
-            break;
-        case com_dump :
-            args->com_read_data.segment = mem_flash;
-            args->com_flash_data.force = 0;
-            break;
-        case com_bin2hex :
-            args->com_convert_data.segment = mem_flash;
-            break;
-        default :
-            break;
+    switch (args->command) {
+    case com_flash:
+        args->com_flash_data.force = 0;
+        args->com_flash_data.segment = mem_flash;
+        break;
+    case com_launch: args->com_launch_config.noreset = 0; break;
+    case com_dump:
+        args->com_read_data.segment = mem_flash;
+        args->com_flash_data.force = 0;
+        break;
+    case com_bin2hex: args->com_convert_data.segment = mem_flash; break;
+    default: break;
     }
 
-    if( 0 != assign_global_options(args, argc, argv) ) {
+    if (0 != assign_global_options (args, argc, argv)) {
         status = -5;
         goto done;
     }
 
-    if( 0 != assign_command_options(args, argc, argv) ) {
+    if (0 != assign_command_options (args, argc, argv)) {
         status = -6;
         goto done;
     }
 
     /* Make sure there weren't any *extra* options. */
-    for( i = 0; i < argc; i++ ) {
-        if( '\0' != *argv[i] ) {
-            fprintf( stderr, "unrecognized parameter\n" );
+    for (i = 0; i < argc; i++) {
+        if ('\0' != *argv[i]) {
+            fprintf (stderr, "unrecognized parameter\n");
             status = -7;
             goto done;
         }
     }
 
     /* if this is a flash command, restore the filename */
-    if( (com_flash == args->command) || (com_eflash == args->command)
-            || (com_user == args->command) ) {
-        if( 0 == args->com_flash_data.file ) {
-// TODO : it should be ok to not have a filename if --serial=hexdigits:offset is
-// provided, this should be implemented.. in fact, given that most of this
-// program is written to use a single command by it self, this probably should
-// be separated out as a new command.  The caveat is if data is written to '\0'
-// in the hex file, serialize will do nothing bc can't un-write w/o erase
-            fprintf( stderr, "flash filename is missing\n" );
+    if ((com_flash == args->command) || (com_eflash == args->command) || (com_user == args->command)) {
+        if (0 == args->com_flash_data.file) {
+            // TODO : it should be ok to not have a filename if --serial=hexdigits:offset is
+            // provided, this should be implemented.. in fact, given that most of this
+            // program is written to use a single command by it self, this probably should
+            // be separated out as a new command.  The caveat is if data is written to '\0'
+            // in the hex file, serialize will do nothing bc can't un-write w/o erase
+            fprintf (stderr, "flash filename is missing\n");
             status = -8;
             goto done;
         }
         args->com_flash_data.file[0] = args->com_flash_data.original_first_char;
     }
 
-    if( (com_bin2hex == args->command) || (com_hex2bin == args->command) ) {
-        if( 0 == args->com_convert_data.file ) {
-            fprintf( stderr, "conversion filename is missing\n" );
+    if ((com_bin2hex == args->command) || (com_hex2bin == args->command)) {
+        if (0 == args->com_convert_data.file) {
+            fprintf (stderr, "conversion filename is missing\n");
             status = -8;
             goto done;
         }
         args->com_convert_data.file[0] = args->com_convert_data.original_first_char;
 
-        if ( com_bin2hex == args->command ) {
-            return execute_bin2hex( args );
+        if (com_bin2hex == args->command) {
+            return execute_bin2hex (args);
         } else {
-            return execute_hex2bin( args );
+            return execute_hex2bin (args);
         }
     }
 
 done:
-    if( 1 < debug ) {
-        print_args( args );
-    }
+    if (1 < debug) { print_args (args); }
 
-    if(-3 == status ) {
-        list_targets( LIST_STD );
-    } else if( 0 != status ) {
-        usage();
+    if (-3 == status) {
+        list_targets (LIST_STD);
+    } else if (0 != status) {
+        usage ();
     }
 
     return status;

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -23,10 +23,10 @@
 
 #include <stdbool.h>
 
-#include "dfu-device.h"
 #include "atmel.h"
+#include "dfu-device.h"
 
-#define DEVICE_TYPE_STRING_MAX_LENGTH   6
+#define DEVICE_TYPE_STRING_MAX_LENGTH 6
 /*
  *  atmel_programmer target command
  *
@@ -34,143 +34,192 @@
  *  dump [--quiet, --debug level]
  *  erase [--suppress-validation, --quiet, --debug level]
  *  flash [--suppress-validation, --quiet, --debug level] file
- *  get {bootloader-version|ID1|ID2|BSB|SBV|SSB|EB|manufacturer|family|product-name|product-revision|HSB} [--quiet, --debug level]
- *  launch [--no-reset]
+ *  get {bootloader-version|ID1|ID2|BSB|SBV|SSB|EB|manufacturer|family|product-name|product-revision|HSB} [--quiet,
+ * --debug level] launch [--no-reset]
  */
 
 enum return_codes_enum {
     SUCCESS = 0,
-    UNSPECIFIED_ERROR,                  /* general error */
-    ARGUMENT_ERROR,                     /* invalid command for target etc. */
-    DEVICE_ACCESS_ERROR,                /* security bit etc. */
-    BUFFER_INIT_ERROR,                  /* hex files problems etc. */
+    UNSPECIFIED_ERROR,   /* general error */
+    ARGUMENT_ERROR,      /* invalid command for target etc. */
+    DEVICE_ACCESS_ERROR, /* security bit etc. */
+    BUFFER_INIT_ERROR,   /* hex files problems etc. */
     FLASH_READ_ERROR,
     FLASH_WRITE_ERROR,
     VALIDATION_ERROR_IN_REGION,
-    VALIDATION_ERROR_OUTSIDE_REGION };
+    VALIDATION_ERROR_OUTSIDE_REGION
+};
 
-enum targets_enum { tar_at89c51snd1c,
-                    tar_at89c51snd2c,
-                    tar_at89c5130,
-                    tar_at89c5131,
-                    tar_at89c5132,
-                    tar_at90usb1287,
-                    tar_at90usb1286,
-                    tar_at90usb1287_4k,
-                    tar_at90usb1286_4k,
-                    tar_at90usb647,
-                    tar_at90usb646,
-                    tar_at90usb162,
-                    tar_at90usb82,
-                    tar_atmega32u6,
-                    tar_atmega32u4,
-                    tar_atmega32u2,
-                    tar_atmega16u4,
-                    tar_atmega16u2,
-                    tar_atmega8u2,
-                    tar_at32uc3b064,
-                    tar_at32uc3b164,
-                    tar_at32uc3b0128,
-                    tar_at32uc3b1128,
-                    tar_at32uc3b0256,
-                    tar_at32uc3b1256,
-                    tar_at32uc3b0256es,
-                    tar_at32uc3b1256es,
-                    tar_at32uc3b0512,
-                    tar_at32uc3b1512,
-                    tar_at32uc3a0128,
-                    tar_at32uc3a1128,
-                    tar_at32uc3a0256,
-                    tar_at32uc3a1256,
-                    tar_at32uc3a0512,
-                    tar_at32uc3a1512,
-                    tar_at32uc3a0512es,
-                    tar_at32uc3a1512es,
-                    tar_at32uc3a364,
-                    tar_at32uc3a364s,
-                    tar_at32uc3a3128,
-                    tar_at32uc3a3128s,
-                    tar_at32uc3a3256,
-                    tar_at32uc3a3256s,
-                    tar_at32uc3a4256s,
-                    tar_at32uc3c064,
-                    tar_at32uc3c0128,
-                    tar_at32uc3c0256,
-                    tar_at32uc3c0512,
-                    tar_at32uc3c164,
-                    tar_at32uc3c1128,
-                    tar_at32uc3c1256,
-                    tar_at32uc3c1512,
-                    tar_at32uc3c264,
-                    tar_at32uc3c2128,
-                    tar_at32uc3c2256,
-                    tar_at32uc3c2512,
-                    tar_atxmega64a1u,
-                    tar_atxmega128a1u,
-                    tar_atxmega64a3u,
-                    tar_atxmega128a3u,
-                    tar_atxmega192a3u,
-                    tar_atxmega256a3u,
-                    tar_atxmega16a4u,
-                    tar_atxmega32a4u,
-                    tar_atxmega64a4u,
-                    tar_atxmega128a4u,
-                    tar_atxmega256a3bu,
-                    tar_atxmega64b1,
-                    tar_atxmega128b1,
-                    tar_atxmega64b3,
-                    tar_atxmega128b3,
-                    tar_atxmega64c3,
-                    tar_atxmega128c3,
-                    tar_atxmega256c3,
-                    tar_atxmega384c3,
-                    tar_atxmega16c4,
-                    tar_atxmega32c4,
-                    tar_stm32f4_B,
-                    tar_stm32f4_C,
-                    tar_stm32f4_E,
-                    tar_stm32f4_G,
-                    tar_none };
+enum targets_enum {
+    tar_at89c51snd1c,
+    tar_at89c51snd2c,
+    tar_at89c5130,
+    tar_at89c5131,
+    tar_at89c5132,
+    tar_at90usb1287,
+    tar_at90usb1286,
+    tar_at90usb1287_4k,
+    tar_at90usb1286_4k,
+    tar_at90usb647,
+    tar_at90usb646,
+    tar_at90usb162,
+    tar_at90usb82,
+    tar_atmega32u6,
+    tar_atmega32u4,
+    tar_atmega32u2,
+    tar_atmega16u4,
+    tar_atmega16u2,
+    tar_atmega8u2,
+    tar_at32uc3b064,
+    tar_at32uc3b164,
+    tar_at32uc3b0128,
+    tar_at32uc3b1128,
+    tar_at32uc3b0256,
+    tar_at32uc3b1256,
+    tar_at32uc3b0256es,
+    tar_at32uc3b1256es,
+    tar_at32uc3b0512,
+    tar_at32uc3b1512,
+    tar_at32uc3a0128,
+    tar_at32uc3a1128,
+    tar_at32uc3a0256,
+    tar_at32uc3a1256,
+    tar_at32uc3a0512,
+    tar_at32uc3a1512,
+    tar_at32uc3a0512es,
+    tar_at32uc3a1512es,
+    tar_at32uc3a364,
+    tar_at32uc3a364s,
+    tar_at32uc3a3128,
+    tar_at32uc3a3128s,
+    tar_at32uc3a3256,
+    tar_at32uc3a3256s,
+    tar_at32uc3a4256s,
+    tar_at32uc3c064,
+    tar_at32uc3c0128,
+    tar_at32uc3c0256,
+    tar_at32uc3c0512,
+    tar_at32uc3c164,
+    tar_at32uc3c1128,
+    tar_at32uc3c1256,
+    tar_at32uc3c1512,
+    tar_at32uc3c264,
+    tar_at32uc3c2128,
+    tar_at32uc3c2256,
+    tar_at32uc3c2512,
+    tar_atxmega64a1u,
+    tar_atxmega128a1u,
+    tar_atxmega64a3u,
+    tar_atxmega128a3u,
+    tar_atxmega192a3u,
+    tar_atxmega256a3u,
+    tar_atxmega16a4u,
+    tar_atxmega32a4u,
+    tar_atxmega64a4u,
+    tar_atxmega128a4u,
+    tar_atxmega256a3bu,
+    tar_atxmega64b1,
+    tar_atxmega128b1,
+    tar_atxmega64b3,
+    tar_atxmega128b3,
+    tar_atxmega64c3,
+    tar_atxmega128c3,
+    tar_atxmega256c3,
+    tar_atxmega384c3,
+    tar_atxmega16c4,
+    tar_atxmega32c4,
+    tar_stm32f4_B,
+    tar_stm32f4_C,
+    tar_stm32f4_E,
+    tar_stm32f4_G,
+    tar_none
+};
 
-enum commands_enum { com_none, com_erase, com_flash, com_user, com_eflash,
-                     com_configure, com_get, com_getfuse, com_dump, com_edump,
-                     com_udump, com_setfuse, com_setsecure, com_start_app,
-                     com_reset, com_launch, com_read, com_hex2bin, com_bin2hex };
+enum commands_enum {
+    com_none,
+    com_erase,
+    com_flash,
+    com_user,
+    com_eflash,
+    com_configure,
+    com_get,
+    com_getfuse,
+    com_dump,
+    com_edump,
+    com_udump,
+    com_setfuse,
+    com_setsecure,
+    com_start_app,
+    com_reset,
+    com_launch,
+    com_read,
+    com_hex2bin,
+    com_bin2hex
+};
 
-enum configure_enum { conf_BSB = ATMEL_SET_CONFIG_BSB,
-                      conf_SBV = ATMEL_SET_CONFIG_SBV,
-                      conf_SSB = ATMEL_SET_CONFIG_SSB,
-                      conf_EB  = ATMEL_SET_CONFIG_EB,
-                      conf_HSB = ATMEL_SET_CONFIG_HSB };
+enum configure_enum {
+    conf_BSB = ATMEL_SET_CONFIG_BSB,
+    conf_SBV = ATMEL_SET_CONFIG_SBV,
+    conf_SSB = ATMEL_SET_CONFIG_SSB,
+    conf_EB = ATMEL_SET_CONFIG_EB,
+    conf_HSB = ATMEL_SET_CONFIG_HSB
+};
 
-enum setfuse_enum { set_lock, set_epfl, set_bootprot, set_bodlevel,
-                    set_bodhyst, set_boden, set_isp_bod_en,
-                    set_isp_io_cond_en, set_isp_force };
+enum setfuse_enum {
+    set_lock,
+    set_epfl,
+    set_bootprot,
+    set_bodlevel,
+    set_bodhyst,
+    set_boden,
+    set_isp_bod_en,
+    set_isp_io_cond_en,
+    set_isp_force
+};
 
-enum get_enum { get_bootloader, get_ID1, get_ID2, get_BSB, get_SBV, get_SSB,
-                get_EB, get_manufacturer, get_family, get_product_name,
-                get_product_rev, get_HSB };
+enum get_enum {
+    get_bootloader,
+    get_ID1,
+    get_ID2,
+    get_BSB,
+    get_SBV,
+    get_SSB,
+    get_EB,
+    get_manufacturer,
+    get_family,
+    get_product_name,
+    get_product_rev,
+    get_HSB
+};
 
-enum getfuse_enum { get_lock, get_epfl, get_bootprot, get_bodlevel,
-                    get_bodhyst, get_boden, get_isp_bod_en,
-                    get_isp_io_cond_en, get_isp_force };
+enum getfuse_enum {
+    get_lock,
+    get_epfl,
+    get_bootprot,
+    get_bodlevel,
+    get_bodhyst,
+    get_boden,
+    get_isp_bod_en,
+    get_isp_io_cond_en,
+    get_isp_force
+};
 
 struct programmer_arguments {
     /* target-specific inputs */
     enum targets_enum target;
     uint16_t vendor_id;
     uint16_t chip_id;
-    uint16_t bus_id;            /* if non-zero, use bus_id and device_address */
-    uint16_t device_address;    /* to identify the specific target device.    */
+    uint16_t bus_id;         /* if non-zero, use bus_id and device_address */
+    uint16_t device_address; /* to identify the specific target device.    */
     atmel_device_class_t device_type;
     char device_type_string[DEVICE_TYPE_STRING_MAX_LENGTH];
-    uint32_t memory_address_top;        /* the maximum flash memory addr.  */
-    uint32_t memory_address_bottom;     /*    including bootloader region  */
-    uint32_t flash_address_top;         /* the maximum flash-able address  */
-    uint32_t flash_address_bottom;      /*     excludes bootloader region  */
-    uint32_t bootloader_top;            /* top of the bootloader region    */
-    uint32_t bootloader_bottom;         /* bottom of the bootloader region */
-    size_t flash_page_size;             /* size of a page in bytes         */
+    uint32_t memory_address_top;    /* the maximum flash memory addr.  */
+    uint32_t memory_address_bottom; /*    including bootloader region  */
+    uint32_t flash_address_top;     /* the maximum flash-able address  */
+    uint32_t flash_address_bottom;  /*     excludes bootloader region  */
+    uint32_t bootloader_top;        /* top of the bootloader region    */
+    uint32_t bootloader_bottom;     /* bottom of the bootloader region */
+    size_t flash_page_size;         /* size of a page in bytes         */
     bool initial_abort;
     bool honor_interfaceclass;
     size_t eeprom_memory_size;
@@ -195,7 +244,7 @@ struct programmer_arguments {
 
         struct com_read_struct {
             bool bin;
-            bool force;             /* do not remove blank pages */
+            bool force; /* do not remove blank pages */
             enum atmel_memory_unit_enum segment;
         } com_read_data;
 
@@ -215,21 +264,21 @@ struct programmer_arguments {
             int16_t *serial_data; /* serial number or other device specific bytes */
             size_t serial_offset; /* where the serial_data should be written */
             size_t serial_length; /* how many bytes to write */
-            bool force;       /* bootloader configuration for UC3 devices
-                                     is on last one or two words in the user
-                                     page depending on the version of the
-                                     bootloader - force overwrite required */
-            bool validate_first; /* Do a validate before flashing */
-            bool ignore_outside; /* Ignore validate errors outside region */
+            bool force;           /* bootloader configuration for UC3 devices
+                                         is on last one or two words in the user
+                                         page depending on the version of the
+                                         bootloader - force overwrite required */
+            bool validate_first;  /* Do a validate before flashing */
+            bool ignore_outside;  /* Ignore validate errors outside region */
             enum atmel_memory_unit_enum segment;
         } com_flash_data;
 
         struct com_convert_struct {
-            size_t bin_offset;          // where the bin data starts
+            size_t bin_offset; // where the bin data starts
             char original_first_char;
-            bool force;             /* do not remove blank pages */
-            char *file;                 // for bin2hex / hex2bin conversions
-            enum atmel_memory_unit_enum segment;    // to auto-select offset
+            bool force;                          /* do not remove blank pages */
+            char *file;                          // for bin2hex / hex2bin conversions
+            enum atmel_memory_unit_enum segment; // to auto-select offset
         } com_convert_data;
 
         struct com_get_struct {
@@ -242,7 +291,5 @@ struct programmer_arguments {
     };
 };
 
-int32_t parse_arguments( struct programmer_arguments *args,
-                         const size_t argc,
-                         char **argv );
+int32_t parse_arguments (struct programmer_arguments *args, const size_t argc, char **argv);
 #endif

--- a/src/atmel.c
+++ b/src/atmel.c
@@ -18,23 +18,22 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <string.h>
-#include <stddef.h>
 #include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <stdbool.h>
 
-#include "dfu-device.h"
-#include "config.h"
 #include "arguments.h"
-#include "dfu.h"
 #include "atmel.h"
+#include "config.h"
+#include "dfu-device.h"
+#include "dfu.h"
 #include "util.h"
-
 
 /* Atmel's firmware doesn't export a DFU descriptor in its config
  * descriptor, so we have to guess about parameters listed there.
@@ -43,68 +42,55 @@
 /* a 64kb page contains 0x10000 values (0 to 0xFFFF).  For the largest 512 kb
  * devices (2^19 bytes) there should be 8 pages.
  */
-#define ATMEL_64KB_PAGE             0x10000
-#define ATMEL_MAX_TRANSFER_SIZE     0x0400
-#define ATMEL_MAX_FLASH_BUFFER_SIZE (ATMEL_MAX_TRANSFER_SIZE +              \
-                                        ATMEL_AVR32_CONTROL_BLOCK_SIZE +    \
-                                        ATMEL_AVR32_CONTROL_BLOCK_SIZE +    \
-                                        ATMEL_FOOTER_SIZE)
+#define ATMEL_64KB_PAGE         0x10000
+#define ATMEL_MAX_TRANSFER_SIZE 0x0400
+#define ATMEL_MAX_FLASH_BUFFER_SIZE                                                                                    \
+    (ATMEL_MAX_TRANSFER_SIZE + ATMEL_AVR32_CONTROL_BLOCK_SIZE + ATMEL_AVR32_CONTROL_BLOCK_SIZE + ATMEL_FOOTER_SIZE)
 
-#define ATMEL_FOOTER_SIZE               16
-#define ATMEL_CONTROL_BLOCK_SIZE        32
-#define ATMEL_AVR32_CONTROL_BLOCK_SIZE  64
+#define ATMEL_FOOTER_SIZE              16
+#define ATMEL_CONTROL_BLOCK_SIZE       32
+#define ATMEL_AVR32_CONTROL_BLOCK_SIZE 64
 
-#define ATMEL_DEBUG_THRESHOLD   50
-#define ATMEL_TRACE_THRESHOLD   55
+#define ATMEL_DEBUG_THRESHOLD 50
+#define ATMEL_TRACE_THRESHOLD 55
 
-#define DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
-                               ATMEL_DEBUG_THRESHOLD, __VA_ARGS__ )
-#define TRACE(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
-                               ATMEL_TRACE_THRESHOLD, __VA_ARGS__ )
+#define DEBUG(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, ATMEL_DEBUG_THRESHOLD, __VA_ARGS__)
+#define TRACE(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, ATMEL_TRACE_THRESHOLD, __VA_ARGS__)
 
+#define PROGRESS_METER "0%%                            100%%  "
+#define PROGRESS_START "["
+#define PROGRESS_BAR   ">"
+#define PROGRESS_END   "]  "
+#define PROGRESS_ERROR " X  "
 
-#define PROGRESS_METER  "0%%                            100%%  "
-#define PROGRESS_START  "["
-#define PROGRESS_BAR    ">"
-#define PROGRESS_END    "]  "
-#define PROGRESS_ERROR  " X  "
-
-extern int debug;       /* defined in main.c */
+extern int debug; /* defined in main.c */
 
 // ________  P R O T O T Y P E S  _______________________________
-static int32_t atmel_read_command( dfu_device_t *device,
-                                   const uint8_t data0,
-                                   const uint8_t data1 );
+static int32_t atmel_read_command (dfu_device_t *device, const uint8_t data0, const uint8_t data1);
 /* returns 0 - 255 on success, < 0 otherwise
  *
  * but what is it used for??
  */
 
-static int32_t __atmel_flash_block( dfu_device_t *device,
-                                    intel_buffer_out_t *bout,
-                                    const bool eeprom );
+static int32_t __atmel_flash_block (dfu_device_t *device, intel_buffer_out_t *bout, const bool eeprom);
 /* flash the contents of memory into a block of memory.  it is assumed that the
  * appropriate page has already been selected.  start and end are the start and
  * end addresses of the flash data.  returns 0 on success, positive dfu error
  * code if one is obtained, or negative if communication with device fails.
  */
 
-static int32_t atmel_select_memory_unit( dfu_device_t *device,
-        enum atmel_memory_unit_enum unit );
+static int32_t atmel_select_memory_unit (dfu_device_t *device, enum atmel_memory_unit_enum unit);
 /* select a memory unit from the following list (enumerated)
  * flash, eeprom, security, configuration, bootloader, signature, user page
  */
 
-static int32_t atmel_select_page( dfu_device_t *device,
-                                  const uint16_t mem_page );
+static int32_t atmel_select_page (dfu_device_t *device, const uint16_t mem_page);
 /* select a page in memory, numbering starts with 0, pages are
  * 64kb pages (0x10000 bytes).  Select page when the memory unit
  * is set to the user page will cause an error.
  */
 
-static int32_t __atmel_blank_page_check( dfu_device_t *device,
-                                         const uint32_t start,
-                                         const uint32_t end );
+static int32_t __atmel_blank_page_check (dfu_device_t *device, const uint32_t start, const uint32_t end);
 /* use to check if a certain address range on the current page is blank
  * it assumes current page has previously been selected.
  * returns 0 if the page is blank
@@ -112,82 +98,72 @@ static int32_t __atmel_blank_page_check( dfu_device_t *device,
  * returns a negative number if the blank check fails
  */
 
-static int32_t __atmel_read_block( dfu_device_t *device,
-                                   intel_buffer_in_t *buin,
-                                   const bool eeprom );
+static int32_t __atmel_read_block (dfu_device_t *device, intel_buffer_in_t *buin, const bool eeprom);
 /* assumes block does not cross 64 b page boundaries and ideally aligns
  * with flash pages. appropriate memory type and 64kb page has already
  * been selected, max transfer size is not violated it updates the buffer
  * data between data_start and data_end
  */
 
-static inline void __print_progress( intel_buffer_info_t *info,
-                                        uint32_t *progress );
+static inline void __print_progress (intel_buffer_info_t *info, uint32_t *progress);
 /* calculate how many progress indicator steps to print and print them
  * update progress value
  */
 
 // ________  F U N C T I O N S  _______________________________
-static int32_t atmel_read_command( dfu_device_t *device,
-                                   const uint8_t data0,
-                                   const uint8_t data1 ) {
+static int32_t
+atmel_read_command (dfu_device_t *device, const uint8_t data0, const uint8_t data1) {
     intel_buffer_in_t buin;
     uint8_t buffer[4];
 
-    TRACE( "%s( %p, 0x%02x, 0x%02x )\n", __FUNCTION__, device, data0, data1 );
+    TRACE ("%s( %p, 0x%02x, 0x%02x )\n", __FUNCTION__, device, data0, data1);
 
     // init the necessary parts of buin
     buin.info.block_start = data1;
     buin.info.block_end = data1;
     buin.data = buffer;
 
-    if( NULL == device ) {
-        DEBUG( "invalid arguments.\n" );
+    if (NULL == device) {
+        DEBUG ("invalid arguments.\n");
         return -1;
     }
 
-    if( GRP_AVR32 & device->type ) {
-        //We need to talk to configuration memory.  It comes
-        //in two varieties in this chip.  data0 is the command to
-        //select it. Data1 is the byte of that group we want
+    if (GRP_AVR32 & device->type) {
+        // We need to talk to configuration memory.  It comes
+        // in two varieties in this chip.  data0 is the command to
+        // select it. Data1 is the byte of that group we want
 
-        if( 0 != atmel_select_memory_unit(device, data0) ) {
-            return -3;
-        }
+        if (0 != atmel_select_memory_unit (device, data0)) { return -3; }
 
-        if( 0 != __atmel_read_block(device, &buin, false) ) {
-            return -5;
-        }
+        if (0 != __atmel_read_block (device, &buin, false)) { return -5; }
 
         return (0xff & buffer[data1]);
     } else {
         uint8_t command[3] = { 0x05, 0x00, 0x00 };
-        uint8_t data[1]    = { 0x00 };
+        uint8_t data[1] = { 0x00 };
         dfu_status_t status;
 
         command[1] = data0;
         command[2] = data1;
 
-
-        if( 3 != dfu_download(device, 3, command) ) {
-            DEBUG( "dfu_download failed\n" );
+        if (3 != dfu_download (device, 3, command)) {
+            DEBUG ("dfu_download failed\n");
             return -1;
         }
 
-        if( 0 != dfu_get_status(device, &status) ) {
-            DEBUG( "dfu_get_status failed\n" );
+        if (0 != dfu_get_status (device, &status)) {
+            DEBUG ("dfu_get_status failed\n");
             return -2;
         }
 
-        if( DFU_STATUS_OK != status.bStatus ) {
-            DEBUG( "status(%s) was not OK.\n",
-                   dfu_status_to_string(status.bStatus) );
-            dfu_clear_status( device );
+        if (DFU_STATUS_OK != status.bStatus) {
+            DEBUG ("status(%s) was not OK.\n", dfu_status_to_string (status.bStatus));
+            dfu_clear_status (device);
             return -3;
         }
 
-        if( 1 != dfu_upload(device, 1, data) ) {
-            DEBUG( "dfu_upload failed\n" );
+        if (1 != dfu_upload (device, 1, data)) {
+            DEBUG ("dfu_upload failed\n");
             return -4;
         }
 
@@ -195,18 +171,18 @@ static int32_t atmel_read_command( dfu_device_t *device,
     }
 }
 
-static inline void __print_progress( intel_buffer_info_t *info,
-                                        uint32_t *progress ) {
-    if ( !(debug > ATMEL_DEBUG_THRESHOLD) && isatty(2) ) {
-        while ( ((info->block_end - info->data_start + 1) * 32) > *progress ) {
-            fprintf( stderr, PROGRESS_BAR );
+static inline void
+__print_progress (intel_buffer_info_t *info, uint32_t *progress) {
+    if (!(debug > ATMEL_DEBUG_THRESHOLD) && isatty (2)) {
+        while (((info->block_end - info->data_start + 1) * 32) > *progress) {
+            fprintf (stderr, PROGRESS_BAR);
             *progress += info->data_end - info->data_start + 1;
         }
     }
 }
 
-int32_t atmel_read_fuses( dfu_device_t *device,
-                           atmel_avr32_fuses_t *info ) {
+int32_t
+atmel_read_fuses (dfu_device_t *device, atmel_avr32_fuses_t *info) {
     intel_buffer_in_t buin;
     uint8_t buffer[32];
     int i;
@@ -216,35 +192,27 @@ int32_t atmel_read_fuses( dfu_device_t *device,
     buin.info.block_end = 31;
     buin.data = buffer;
 
-    if( NULL == device ) {
-        DEBUG( "invalid arguments.\n" );
+    if (NULL == device) {
+        DEBUG ("invalid arguments.\n");
         return ARGUMENT_ERROR;
     }
 
-    if( !(ADC_AVR32 & device->type) ) {
-        DEBUG( "target does not support fuse operation.\n" );
-        fprintf( stderr, "target does not support fuse operation.\n" );
+    if (!(ADC_AVR32 & device->type)) {
+        DEBUG ("target does not support fuse operation.\n");
+        fprintf (stderr, "target does not support fuse operation.\n");
         return ARGUMENT_ERROR;
     }
 
-    if( 0 != atmel_select_memory_unit(device, mem_config) ) {
-        return -3;
-    }
+    if (0 != atmel_select_memory_unit (device, mem_config)) { return -3; }
 
-    if( 0 != __atmel_read_block(device, &buin, false) ) {
-            return -5;
-    }
+    if (0 != __atmel_read_block (device, &buin, false)) { return -5; }
 
     info->lock = 0;
-    for(i = 0; i < 16; i++) {
-        info->lock = info->lock | (buffer[i] << i);
-    }
+    for (i = 0; i < 16; i++) { info->lock = info->lock | (buffer[i] << i); }
     info->epfl = buffer[16];
     info->bootprot = (buffer[19] << 2) | (buffer[18] << 1) | (buffer[17] << 0);
     info->bodlevel = 0;
-    for(i = 20; i < 26; i++) {
-        info->bodlevel = info->bodlevel | (buffer[i] << (i-20));
-    }
+    for (i = 20; i < 26; i++) { info->bodlevel = info->bodlevel | (buffer[i] << (i - 20)); }
     info->bodhyst = buffer[26];
     info->boden = (buffer[28] << 1) | (buffer[27] << 0);
     info->isp_bod_en = buffer[29];
@@ -254,63 +222,59 @@ int32_t atmel_read_fuses( dfu_device_t *device,
     return 0;
 }
 
-int32_t atmel_read_config( dfu_device_t *device,
-                           atmel_device_info_t *info ) {
+int32_t
+atmel_read_config (dfu_device_t *device, atmel_device_info_t *info) {
     typedef struct {
         uint8_t data0;
         uint8_t data1;
         uint8_t device_map;
-        size_t  offset;
+        size_t offset;
     } atmel_read_config_t;
 
     /* These commands are documented in Appendix A of the
      * "AT89C5131A USB Bootloader Datasheet" or
      * "AT90usb128x/AT90usb64x USB DFU Bootloader Datasheet"
      */
-    static const atmel_read_config_t data[] = {
-        { 0x00, 0x00, (ADC_8051 | ADC_AVR), offsetof(atmel_device_info_t, bootloaderVersion) },
-        { 0x04, 0x00, (ADC_AVR32 | ADC_XMEGA),          offsetof(atmel_device_info_t, bootloaderVersion) },
-        { 0x00, 0x01, (ADC_8051 | ADC_AVR), offsetof(atmel_device_info_t, bootID1)           },
-        { 0x04, 0x01, (ADC_AVR32 | ADC_XMEGA),          offsetof(atmel_device_info_t, bootID1)           },
-        { 0x00, 0x02, (ADC_8051 | ADC_AVR), offsetof(atmel_device_info_t, bootID2)           },
-        { 0x04, 0x02, (ADC_AVR32 | ADC_XMEGA),          offsetof(atmel_device_info_t, bootID2)           },
-        { 0x01, 0x30, (ADC_8051 | ADC_AVR), offsetof(atmel_device_info_t, manufacturerCode)  },
-        { 0x05, 0x00, (ADC_AVR32 | ADC_XMEGA),          offsetof(atmel_device_info_t, manufacturerCode)  },
-        { 0x01, 0x31, (ADC_8051 | ADC_AVR), offsetof(atmel_device_info_t, familyCode)        },
-        { 0x05, 0x01, (ADC_AVR32 | ADC_XMEGA),          offsetof(atmel_device_info_t, familyCode)        },
-        { 0x01, 0x60, (ADC_8051 | ADC_AVR), offsetof(atmel_device_info_t, productName)       },
-        { 0x05, 0x02, (ADC_AVR32 | ADC_XMEGA),          offsetof(atmel_device_info_t, productName)       },
-        { 0x01, 0x61, (ADC_8051 | ADC_AVR), offsetof(atmel_device_info_t, productRevision)   },
-        { 0x05, 0x03, (ADC_AVR32 | ADC_XMEGA),          offsetof(atmel_device_info_t, productRevision)   },
-        { 0x01, 0x00, ADC_8051,             offsetof(atmel_device_info_t, bsb)               },
-        { 0x01, 0x01, ADC_8051,             offsetof(atmel_device_info_t, sbv)               },
-        { 0x01, 0x05, ADC_8051,             offsetof(atmel_device_info_t, ssb)               },
-        { 0x01, 0x06, ADC_8051,             offsetof(atmel_device_info_t, eb)                },
-        { 0x02, 0x00, ADC_8051,             offsetof(atmel_device_info_t, hsb)               }
-    };
+    static const atmel_read_config_t data[]
+        = { { 0x00, 0x00, (ADC_8051 | ADC_AVR), offsetof (atmel_device_info_t, bootloaderVersion) },
+            { 0x04, 0x00, (ADC_AVR32 | ADC_XMEGA), offsetof (atmel_device_info_t, bootloaderVersion) },
+            { 0x00, 0x01, (ADC_8051 | ADC_AVR), offsetof (atmel_device_info_t, bootID1) },
+            { 0x04, 0x01, (ADC_AVR32 | ADC_XMEGA), offsetof (atmel_device_info_t, bootID1) },
+            { 0x00, 0x02, (ADC_8051 | ADC_AVR), offsetof (atmel_device_info_t, bootID2) },
+            { 0x04, 0x02, (ADC_AVR32 | ADC_XMEGA), offsetof (atmel_device_info_t, bootID2) },
+            { 0x01, 0x30, (ADC_8051 | ADC_AVR), offsetof (atmel_device_info_t, manufacturerCode) },
+            { 0x05, 0x00, (ADC_AVR32 | ADC_XMEGA), offsetof (atmel_device_info_t, manufacturerCode) },
+            { 0x01, 0x31, (ADC_8051 | ADC_AVR), offsetof (atmel_device_info_t, familyCode) },
+            { 0x05, 0x01, (ADC_AVR32 | ADC_XMEGA), offsetof (atmel_device_info_t, familyCode) },
+            { 0x01, 0x60, (ADC_8051 | ADC_AVR), offsetof (atmel_device_info_t, productName) },
+            { 0x05, 0x02, (ADC_AVR32 | ADC_XMEGA), offsetof (atmel_device_info_t, productName) },
+            { 0x01, 0x61, (ADC_8051 | ADC_AVR), offsetof (atmel_device_info_t, productRevision) },
+            { 0x05, 0x03, (ADC_AVR32 | ADC_XMEGA), offsetof (atmel_device_info_t, productRevision) },
+            { 0x01, 0x00, ADC_8051, offsetof (atmel_device_info_t, bsb) },
+            { 0x01, 0x01, ADC_8051, offsetof (atmel_device_info_t, sbv) },
+            { 0x01, 0x05, ADC_8051, offsetof (atmel_device_info_t, ssb) },
+            { 0x01, 0x06, ADC_8051, offsetof (atmel_device_info_t, eb) },
+            { 0x02, 0x00, ADC_8051, offsetof (atmel_device_info_t, hsb) } };
 
     int32_t result;
     int32_t retVal = 0;
     int32_t i = 0;
 
-    TRACE( "%s( %p, %p )\n", __FUNCTION__, device, info );
+    TRACE ("%s( %p, %p )\n", __FUNCTION__, device, info);
 
-    if( NULL == device ) {
-        DEBUG( "invalid arguments.\n" );
+    if (NULL == device) {
+        DEBUG ("invalid arguments.\n");
         return -1;
     }
 
-    for( i = 0; i < sizeof(data)/sizeof(atmel_read_config_t); i++ ) {
-        atmel_read_config_t *row = (atmel_read_config_t*) &data[i];
+    for (i = 0; i < sizeof (data) / sizeof (atmel_read_config_t); i++) {
+        atmel_read_config_t *row = (atmel_read_config_t *)&data[i];
 
-        if( row->device_map & device->type )
-        {
-            int16_t *ptr = row->offset + (void *) info;
+        if (row->device_map & device->type) {
+            int16_t *ptr = row->offset + (void *)info;
 
-            result = atmel_read_command( device, row->data0, row->data1 );
-            if( result < 0 ) {
-                retVal = result;
-            }
+            result = atmel_read_command (device, row->data0, row->data1);
+            if (result < 0) { retVal = result; }
             *ptr = result;
         }
     }
@@ -318,308 +282,267 @@ int32_t atmel_read_config( dfu_device_t *device,
     return retVal;
 }
 
-int32_t atmel_erase_flash( dfu_device_t *device,
-                           const uint8_t mode,
-                           bool quiet ) {
+int32_t
+atmel_erase_flash (dfu_device_t *device, const uint8_t mode, bool quiet) {
     uint8_t command[3] = { 0x04, 0x00, 0x00 };
     dfu_status_t status;
     int32_t retries;
     time_t start;
 
-    TRACE( "%s( %p, %d )\n", __FUNCTION__, device, mode );
+    TRACE ("%s( %p, %d )\n", __FUNCTION__, device, mode);
 
-    switch( mode ) {
-        case ATMEL_ERASE_BLOCK_0:
-            command[2] = 0x00;
-            break;
-        case ATMEL_ERASE_BLOCK_1:
-            command[2] = 0x20;
-            break;
-        case ATMEL_ERASE_BLOCK_2:
-            command[2] = 0x40;
-            break;
-        case ATMEL_ERASE_BLOCK_3:
-            command[2] = 0x80;
-            break;
-        case ATMEL_ERASE_ALL:
-            command[2] = 0xff;
-            break;
+    switch (mode) {
+    case ATMEL_ERASE_BLOCK_0: command[2] = 0x00; break;
+    case ATMEL_ERASE_BLOCK_1: command[2] = 0x20; break;
+    case ATMEL_ERASE_BLOCK_2: command[2] = 0x40; break;
+    case ATMEL_ERASE_BLOCK_3: command[2] = 0x80; break;
+    case ATMEL_ERASE_ALL: command[2] = 0xff; break;
 
-        default:
-            return -1;
+    default: return -1;
     }
 
-    if( !quiet ) fprintf( stderr, "Erasing flash...  " );
-    if( 3 != dfu_download(device, 3, command) ) {
-        if( !quiet ) fprintf( stderr, "ERROR\n" );
-        DEBUG( "dfu_download failed\n" );
+    if (!quiet) fprintf (stderr, "Erasing flash...  ");
+    if (3 != dfu_download (device, 3, command)) {
+        if (!quiet) fprintf (stderr, "ERROR\n");
+        DEBUG ("dfu_download failed\n");
         return -2;
     }
 
-    /* It looks like it can take a while to erase the chip.
-     * We will try for 20 seconds before giving up.
-     * Different version of the bootloader behave in different ways.
-     * In some the dfu_get_status() call blocks until the operation completes.
-     * In others it returns immediately with an erase-in-progress status.
-     */
-    #define ERASE_SECONDS 20
-    start = time(NULL);
+/* It looks like it can take a while to erase the chip.
+ * We will try for 20 seconds before giving up.
+ * Different version of the bootloader behave in different ways.
+ * In some the dfu_get_status() call blocks until the operation completes.
+ * In others it returns immediately with an erase-in-progress status.
+ */
+#define ERASE_SECONDS 20
+    start = time (NULL);
     retries = 0;
     do {
-        if( 0 == dfu_get_status(device, &status) ) {
+        if (0 == dfu_get_status (device, &status)) {
             // Status return is valid
-            if( (DFU_STATUS_ERROR_NOTDONE == status.bStatus) &&
-                (STATE_DFU_DOWNLOAD_BUSY == status.bState) ) {
+            if ((DFU_STATUS_ERROR_NOTDONE == status.bStatus) && (STATE_DFU_DOWNLOAD_BUSY == status.bState)) {
                 // Erase is still in progress.
                 // Wait 100ms and get status again.
-                usleep(100000);
+                usleep (100000);
             } else {
                 // Erase complete.
-                if( !quiet ) fprintf( stderr, "Success\n" );
-                DEBUG ( "CMD_ERASE status: Erase Done.\n" );
+                if (!quiet) fprintf (stderr, "Success\n");
+                DEBUG ("CMD_ERASE status: Erase Done.\n");
                 return status.bStatus;
             }
         } else {
             // Status command failed.
-            dfu_clear_status( device );
+            dfu_clear_status (device);
             ++retries;
-            if( !quiet ) fprintf( stderr, "ERROR\n" );
-            DEBUG ( "CMD_ERASE status check %d returned nonzero.\n", retries );
+            if (!quiet) fprintf (stderr, "ERROR\n");
+            DEBUG ("CMD_ERASE status check %d returned nonzero.\n", retries);
         }
-    } while( (retries < 10) && (start != -1) && ((time(NULL) - start) < ERASE_SECONDS) );
+    } while ((retries < 10) && (start != -1) && ((time (NULL) - start) < ERASE_SECONDS));
 
-    if( retries < 10 )
-        DEBUG ( "CMD_ERASE time limit %ds exceeded.\n", ERASE_SECONDS );
+    if (retries < 10) DEBUG ("CMD_ERASE time limit %ds exceeded.\n", ERASE_SECONDS);
 
     return -3;
 }
 
-int32_t atmel_set_fuse( dfu_device_t *device,
-                        const uint8_t property,
-                        const uint32_t value ) {
+int32_t
+atmel_set_fuse (dfu_device_t *device, const uint8_t property, const uint32_t value) {
     uint16_t buffer[16];
     int32_t address;
     int8_t numbytes;
     int8_t i;
     intel_buffer_out_t bout;
 
-    if( NULL == device ) {
-        DEBUG( "invalid arguments.\n" );
+    if (NULL == device) {
+        DEBUG ("invalid arguments.\n");
         return -1;
     }
 
-    if( !(ADC_AVR32 & device->type) ) {
-       DEBUG( "target does not support fuse operation.\n" );
-       fprintf( stderr, "target does not support fuse operation.\n" );
-       return -1;
+    if (!(ADC_AVR32 & device->type)) {
+        DEBUG ("target does not support fuse operation.\n");
+        fprintf (stderr, "target does not support fuse operation.\n");
+        return -1;
     }
 
-    if( 0 != atmel_select_memory_unit(device, mem_config) ) {
-        return -3;
-    }
+    if (0 != atmel_select_memory_unit (device, mem_config)) { return -3; }
 
-    switch( property ) {
-        case set_lock:
-            for( i = 0; i < 16; i++ ) {
-                buffer[i] = value & (0x0001 << i);
-            }
-            numbytes = 16;
-            address = 0;
-            break;
-        case set_epfl:
-            buffer[0] = value & 0x0001;
-            numbytes = 1;
-            address = 16;
-            break;
-        case set_bootprot:
-            buffer[0] = value & 0x0001;
-            buffer[1] = value & 0x0002;
-            buffer[2] = value & 0x0004;
-            numbytes = 3;
-            address = 17;
-            break;
-        case set_bodlevel:
+    switch (property) {
+    case set_lock:
+        for (i = 0; i < 16; i++) { buffer[i] = value & (0x0001 << i); }
+        numbytes = 16;
+        address = 0;
+        break;
+    case set_epfl:
+        buffer[0] = value & 0x0001;
+        numbytes = 1;
+        address = 16;
+        break;
+    case set_bootprot:
+        buffer[0] = value & 0x0001;
+        buffer[1] = value & 0x0002;
+        buffer[2] = value & 0x0004;
+        numbytes = 3;
+        address = 17;
+        break;
+    case set_bodlevel:
 #ifdef SUPPORT_SET_BOD_FUSES
-            /* Enable at your own risk - this has not been tested &
-             * may brick your device. */
-            for(i = 20;i < 26; i++){
-                buffer[i] = value & (0x0001 << (i-20));
-            }
-            numbytes = 6;
-            address = 20;
-            break;
+        /* Enable at your own risk - this has not been tested &
+         * may brick your device. */
+        for (i = 20; i < 26; i++) { buffer[i] = value & (0x0001 << (i - 20)); }
+        numbytes = 6;
+        address = 20;
+        break;
 #else
-            DEBUG( "Setting BODLEVEL can break your chip. Operation not performed\n" );
-            DEBUG( "Rebuild with the SUPPORT_SET_BOD_FUSES #define enabled if you really want to do this.\n" );
-            fprintf( stderr, "Setting BODLEVEL can break your chip. Operation not performed.\n" );
-            return -1;
+        DEBUG ("Setting BODLEVEL can break your chip. Operation not performed\n");
+        DEBUG ("Rebuild with the SUPPORT_SET_BOD_FUSES #define enabled if you really want to do this.\n");
+        fprintf (stderr, "Setting BODLEVEL can break your chip. Operation not performed.\n");
+        return -1;
 #endif
-        case set_bodhyst:
+    case set_bodhyst:
 #ifdef SUPPORT_SET_BOD_FUSES
-            /* Enable at your own risk - this has not been tested &
-             * may brick your device. */
-            buffer[0] = value & 0x0001;
-            numbytes = 1;
-            address = 26;
-            break;
+        /* Enable at your own risk - this has not been tested &
+         * may brick your device. */
+        buffer[0] = value & 0x0001;
+        numbytes = 1;
+        address = 26;
+        break;
 #else
-            DEBUG("Setting BODHYST can break your chip. Operation not performed\n");
-            DEBUG( "Rebuild with the SUPPORT_SET_BOD_FUSES #define enabled if you really want to do this.\n" );
-            fprintf( stderr, "Setting BODHYST can break your chip. Operation not performed.\n");
-            return -1;
+        DEBUG ("Setting BODHYST can break your chip. Operation not performed\n");
+        DEBUG ("Rebuild with the SUPPORT_SET_BOD_FUSES #define enabled if you really want to do this.\n");
+        fprintf (stderr, "Setting BODHYST can break your chip. Operation not performed.\n");
+        return -1;
 #endif
-        case set_boden:
+    case set_boden:
 #ifdef SUPPORT_SET_BOD_FUSES
-            /* Enable at your own risk - this has not been tested &
-             * may brick your device. */
-            buffer[0] = value & 0x0001;
-            buffer[1] = value & 0x0002;
-            numbytes = 2;
-            address = 27;
-            break;
+        /* Enable at your own risk - this has not been tested &
+         * may brick your device. */
+        buffer[0] = value & 0x0001;
+        buffer[1] = value & 0x0002;
+        numbytes = 2;
+        address = 27;
+        break;
 #else
-            DEBUG( "Setting BODEN can break your chip. Operation not performed\n" );
-            DEBUG( "Rebuild with the SUPPORT_SET_BOD_FUSES #define enabled if you really want to do this.\n" );
-            fprintf( stderr, "Setting BODEN can break your chip. Operation not performed.\n" );
-            return -1;
+        DEBUG ("Setting BODEN can break your chip. Operation not performed\n");
+        DEBUG ("Rebuild with the SUPPORT_SET_BOD_FUSES #define enabled if you really want to do this.\n");
+        fprintf (stderr, "Setting BODEN can break your chip. Operation not performed.\n");
+        return -1;
 #endif
-        case set_isp_bod_en:
+    case set_isp_bod_en:
 #ifdef SUPPORT_SET_BOD_FUSES
-            /* Enable at your own risk - this has not been tested &
-             * may brick your device. */
-            buffer[0] = value & 0x0001;
-            numbytes = 1;
-            address = 29;
-            break;
+        /* Enable at your own risk - this has not been tested &
+         * may brick your device. */
+        buffer[0] = value & 0x0001;
+        numbytes = 1;
+        address = 29;
+        break;
 #else
-            DEBUG( "Setting ISP_BOD_EN can break your chip. Operation not performed\n" );
-            DEBUG( "Rebuild with the SUPPORT_SET_BOD_FUSES #define enabled if you really want to do this.\n" );
-            fprintf( stderr, "Setting ISP_BOD_EN can break your chip. Operation not performed.\n" );
-            return -1;
+        DEBUG ("Setting ISP_BOD_EN can break your chip. Operation not performed\n");
+        DEBUG ("Rebuild with the SUPPORT_SET_BOD_FUSES #define enabled if you really want to do this.\n");
+        fprintf (stderr, "Setting ISP_BOD_EN can break your chip. Operation not performed.\n");
+        return -1;
 #endif
-        case set_isp_io_cond_en:
-            buffer[0] = value & 0x0001;
-            numbytes = 1;
-            address = 30;
-            break;
-        case set_isp_force:
-            buffer[0] = value & 0x0001;
-            numbytes = 1;
-            address = 31;
-            break;
-        default:
-            DEBUG( "Fuse bits unrecognized\n" );
-            fprintf( stderr, "Fuse bits unrecognized.\n" );
-            return -2;
-            break;
+    case set_isp_io_cond_en:
+        buffer[0] = value & 0x0001;
+        numbytes = 1;
+        address = 30;
+        break;
+    case set_isp_force:
+        buffer[0] = value & 0x0001;
+        numbytes = 1;
+        address = 31;
+        break;
+    default:
+        DEBUG ("Fuse bits unrecognized\n");
+        fprintf (stderr, "Fuse bits unrecognized.\n");
+        return -2;
+        break;
     }
 
     bout.data = buffer;
     bout.info.block_start = address;
     bout.info.block_end = address + numbytes - 1;
 
-    if( 0 != __atmel_flash_block(device, &bout, false) ) {
-        return -6;
-    }
+    if (0 != __atmel_flash_block (device, &bout, false)) { return -6; }
 
     return 0;
 }
 
-int32_t atmel_set_config( dfu_device_t *device,
-                          const uint8_t property,
-                          const uint8_t value ) {
+int32_t
+atmel_set_config (dfu_device_t *device, const uint8_t property, const uint8_t value) {
     uint8_t command[4] = { 0x04, 0x01, 0x00, 0x00 };
     dfu_status_t status;
 
-    TRACE( "%s( %p, %d, 0x%02x )\n", __FUNCTION__, device, property, value );
+    TRACE ("%s( %p, %d, 0x%02x )\n", __FUNCTION__, device, property, value);
 
-    switch( property ) {
-        case ATMEL_SET_CONFIG_BSB:
-            break;
-        case ATMEL_SET_CONFIG_SBV:
-            command[2] = 0x01;
-            break;
-        case ATMEL_SET_CONFIG_SSB:
-            command[2] = 0x05;
-            break;
-        case ATMEL_SET_CONFIG_EB:
-            command[2] = 0x06;
-            break;
-        case ATMEL_SET_CONFIG_HSB:
-            command[1] = 0x02;
-            break;
-        default:
-            return -1;
+    switch (property) {
+    case ATMEL_SET_CONFIG_BSB: break;
+    case ATMEL_SET_CONFIG_SBV: command[2] = 0x01; break;
+    case ATMEL_SET_CONFIG_SSB: command[2] = 0x05; break;
+    case ATMEL_SET_CONFIG_EB: command[2] = 0x06; break;
+    case ATMEL_SET_CONFIG_HSB: command[1] = 0x02; break;
+    default: return -1;
     }
 
     command[3] = value;
 
-    if( 4 != dfu_download(device, 4, command) ) {
-        DEBUG( "dfu_download failed\n" );
+    if (4 != dfu_download (device, 4, command)) {
+        DEBUG ("dfu_download failed\n");
         return -2;
     }
 
-    if( 0 != dfu_get_status(device, &status) ) {
-        DEBUG( "dfu_get_status failed\n" );
+    if (0 != dfu_get_status (device, &status)) {
+        DEBUG ("dfu_get_status failed\n");
         return -3;
     }
 
-    if( DFU_STATUS_ERROR_WRITE == status.bStatus ) {
-        fprintf( stderr, "Device is write protected.\n" );
-    }
+    if (DFU_STATUS_ERROR_WRITE == status.bStatus) { fprintf (stderr, "Device is write protected.\n"); }
 
     return status.bStatus;
 }
 
-static int32_t __atmel_read_block( dfu_device_t *device,
-                                   intel_buffer_in_t *buin,
-                                   const bool eeprom ) {
+static int32_t
+__atmel_read_block (dfu_device_t *device, intel_buffer_in_t *buin, const bool eeprom) {
     uint8_t command[6] = { 0x03, 0x00, 0x00, 0x00, 0x00, 0x00 };
     int32_t result;
 
-    if( buin->info.block_end < buin->info.block_start ) {
+    if (buin->info.block_end < buin->info.block_start) {
         // this would cause a problem bc read length could be way off
-        DEBUG("ERROR: start address is after end address.\n");
+        DEBUG ("ERROR: start address is after end address.\n");
         return -1;
-    } else if( buin->info.block_end - buin->info.block_start + 1 > ATMEL_MAX_TRANSFER_SIZE ) {
+    } else if (buin->info.block_end - buin->info.block_start + 1 > ATMEL_MAX_TRANSFER_SIZE) {
         // this could cause a read problem
-        DEBUG("ERROR: transfer size must not exceed %d.\n",
-                ATMEL_MAX_TRANSFER_SIZE );
+        DEBUG ("ERROR: transfer size must not exceed %d.\n", ATMEL_MAX_TRANSFER_SIZE);
         return -1;
     }
 
     // AVR/8051 requires 0x02 here to read eeprom, XMEGA requires 0x00.
-    if( true == eeprom && (GRP_AVR & device->type) ) {
-        command[1] = 0x02;
-    }
+    if (true == eeprom && (GRP_AVR & device->type)) { command[1] = 0x02; }
 
     command[2] = 0xff & (buin->info.block_start >> 8);
     command[3] = 0xff & (buin->info.block_start);
     command[4] = 0xff & (buin->info.block_end >> 8);
     command[5] = 0xff & (buin->info.block_end);
 
-    if( 6 != dfu_download(device, 6, command) ) {
-        DEBUG( "dfu_download failed\n" );
+    if (6 != dfu_download (device, 6, command)) {
+        DEBUG ("dfu_download failed\n");
         return -1;
     }
 
-    result = dfu_upload( device, buin->info.block_end - buin->info.block_start + 1,
-                                &buin->data[buin->info.block_start] );
-    if( result < 0) {
+    result
+        = dfu_upload (device, buin->info.block_end - buin->info.block_start + 1, &buin->data[buin->info.block_start]);
+    if (result < 0) {
         dfu_status_t status;
 
-        DEBUG( "dfu_upload result: %d\n", result );
-        if( 0 == dfu_get_status(device, &status) ) {
-            if( DFU_STATUS_ERROR_FILE == status.bStatus ) {
-                fprintf( stderr,
-                            "The device is read protected.\n" );
+        DEBUG ("dfu_upload result: %d\n", result);
+        if (0 == dfu_get_status (device, &status)) {
+            if (DFU_STATUS_ERROR_FILE == status.bStatus) {
+                fprintf (stderr, "The device is read protected.\n");
             } else {
-                fprintf( stderr, "Unknown error. Try enabling debug.\n" );
+                fprintf (stderr, "Unknown error. Try enabling debug.\n");
             }
         } else {
-            fprintf( stderr, "Device is unresponsive.\n" );
+            fprintf (stderr, "Device is unresponsive.\n");
         }
-        dfu_clear_status( device );
+        dfu_clear_status (device);
 
         return result;
     }
@@ -627,60 +550,51 @@ static int32_t __atmel_read_block( dfu_device_t *device,
     return 0;
 }
 
-int32_t atmel_read_flash( dfu_device_t *device,
-                          intel_buffer_in_t *buin,
-                          const uint8_t mem_segment,
-                          const bool quiet ) {
-    uint8_t mem_page = 0;           // tracks the current memory page
-    uint32_t progress = 0;          // used to indicate progress
+int32_t
+atmel_read_flash (dfu_device_t *device, intel_buffer_in_t *buin, const uint8_t mem_segment, const bool quiet) {
+    uint8_t mem_page = 0;  // tracks the current memory page
+    uint32_t progress = 0; // used to indicate progress
     int32_t result = 0;
     // TODO : use status instead of result
-    int32_t retval = -1;            // the return value for this function
+    int32_t retval = -1; // the return value for this function
 
-    TRACE( "%s( %p, %p, %u, %s )\n", __FUNCTION__, device, buin,
-            mem_segment, ((true == quiet) ? "true" : "false"));
+    TRACE ("%s( %p, %p, %u, %s )\n", __FUNCTION__, device, buin, mem_segment, ((true == quiet) ? "true" : "false"));
 
-    if( (NULL == buin) || (NULL == device) ) {
-        DEBUG( "invalid arguments.\n" );
-        if( !quiet )
-            fprintf( stderr, "Program Error, use debug for more info.\n" );
+    if ((NULL == buin) || (NULL == device)) {
+        DEBUG ("invalid arguments.\n");
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
         return -1;
-    } else if ( mem_segment != mem_flash &&
-                mem_segment != mem_user &&
-                mem_segment != mem_eeprom ) {
-        DEBUG( "Invalid memory segment %d to read.\n", mem_segment );
-        if( !quiet )
-            fprintf( stderr, "Program Error, use debug for more info.\n" );
+    } else if (mem_segment != mem_flash && mem_segment != mem_user && mem_segment != mem_eeprom) {
+        DEBUG ("Invalid memory segment %d to read.\n", mem_segment);
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
         return -1;
     }
 
     // For the AVR32/XMEGA chips, select the flash space. (safe for all parts)
-    if( 0 != atmel_select_memory_unit(device, mem_segment) ) {
+    if (0 != atmel_select_memory_unit (device, mem_segment)) {
         DEBUG ("Error selecting memory unit.\n");
-        if( !quiet )
-            fprintf( stderr, "Memory access error, use debug for more info.\n" );
+        if (!quiet) fprintf (stderr, "Memory access error, use debug for more info.\n");
         return -3;
     }
 
-    if( !quiet ) {
-        if( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
+    if (!quiet) {
+        if (debug <= ATMEL_DEBUG_THRESHOLD && isatty (2)) {
             // NOTE: From here on we should go to finally on error
-            fprintf( stderr, PROGRESS_METER );
+            fprintf (stderr, PROGRESS_METER);
         }
-        fprintf( stderr, "Reading 0x%X bytes...\n",
-                buin->info.data_end - buin->info.data_start + 1 );
-        if( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
+        fprintf (stderr, "Reading 0x%X bytes...\n", buin->info.data_end - buin->info.data_start + 1);
+        if (debug <= ATMEL_DEBUG_THRESHOLD && isatty (2)) {
             // NOTE: From here on we should go to finally on error
-            fprintf( stderr, PROGRESS_START );
+            fprintf (stderr, PROGRESS_START);
         }
     }
 
     // select the first memory page ( not safe for mem_user )
     buin->info.block_start = buin->info.data_start;
     mem_page = buin->info.block_start / ATMEL_64KB_PAGE;
-    if ( mem_segment != mem_user ) {
-        if( 0 != (result = atmel_select_page( device, mem_page )) ) {
-            DEBUG( "ERROR selecting 64kB page %d.\n", result );
+    if (mem_segment != mem_user) {
+        if (0 != (result = atmel_select_page (device, mem_page))) {
+            DEBUG ("ERROR selecting 64kB page %d.\n", result);
             retval = -3;
             goto finally;
         }
@@ -688,79 +602,65 @@ int32_t atmel_read_flash( dfu_device_t *device,
 
     while (buin->info.block_start <= buin->info.data_end) {
         // ensure the memory page is correct
-        if ( buin->info.block_start / ATMEL_64KB_PAGE != mem_page ) {
+        if (buin->info.block_start / ATMEL_64KB_PAGE != mem_page) {
             mem_page = buin->info.block_start / ATMEL_64KB_PAGE;
-            if( 0 != (result = atmel_select_page( device, mem_page )) ) {
-                DEBUG( "ERROR selecting 64kB page %d.\n", result );
+            if (0 != (result = atmel_select_page (device, mem_page))) {
+                DEBUG ("ERROR selecting 64kB page %d.\n", result);
                 retval = -3;
             }
             // check if the entire page is blank ()
         }
 
         // find end value for the current transfer
-        buin->info.block_end = buin->info.block_start +
-            ATMEL_MAX_TRANSFER_SIZE - 1;
-        if ( buin->info.block_end / ATMEL_64KB_PAGE > mem_page ) {
+        buin->info.block_end = buin->info.block_start + ATMEL_MAX_TRANSFER_SIZE - 1;
+        if (buin->info.block_end / ATMEL_64KB_PAGE > mem_page) {
             buin->info.block_end = ATMEL_64KB_PAGE * mem_page - 1;
         }
-        if ( buin->info.block_end > buin->info.data_end ) {
-            buin->info.block_end = buin->info.data_end;
-        }
+        if (buin->info.block_end > buin->info.data_end) { buin->info.block_end = buin->info.data_end; }
 
-        if( 0 != (result = __atmel_read_block(device, buin,
-                    mem_segment == mem_eeprom ? 1 : 0)) ) {
-            DEBUG( "Error reading block 0x%X to 0x%X: err %d.\n",
-                    buin->info.block_start, buin->info.block_end, result );
+        if (0 != (result = __atmel_read_block (device, buin, mem_segment == mem_eeprom ? 1 : 0))) {
+            DEBUG ("Error reading block 0x%X to 0x%X: err %d.\n", buin->info.block_start, buin->info.block_end, result);
             retval = -5;
             goto finally;
         }
 
         buin->info.block_start = buin->info.block_end + 1;
-        if ( !quiet ) __print_progress( &buin->info, &progress );
+        if (!quiet) __print_progress (&buin->info, &progress);
     }
     retval = 0;
 
 finally:
-    if ( !quiet ) {
-        if( 0 == retval ) {
-            if ( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
-                fprintf( stderr, PROGRESS_END );
-            }
-            fprintf( stderr, "Success\n" );
+    if (!quiet) {
+        if (0 == retval) {
+            if (debug <= ATMEL_DEBUG_THRESHOLD && isatty (2)) { fprintf (stderr, PROGRESS_END); }
+            fprintf (stderr, "Success\n");
         } else {
-            if ( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
-                fprintf( stderr, PROGRESS_ERROR );
-            }
-            fprintf( stderr, "ERROR\n" );
-            if( retval==-3 )
-                fprintf( stderr,
-                        "Memory access error, use debug for more info.\n" );
-            else if( retval==-5 )
-                fprintf( stderr,
-                        "Memory read error, use debug for more info.\n" );
+            if (debug <= ATMEL_DEBUG_THRESHOLD && isatty (2)) { fprintf (stderr, PROGRESS_ERROR); }
+            fprintf (stderr, "ERROR\n");
+            if (retval == -3)
+                fprintf (stderr, "Memory access error, use debug for more info.\n");
+            else if (retval == -5)
+                fprintf (stderr, "Memory read error, use debug for more info.\n");
         }
     }
     return retval;
 }
 
-static int32_t __atmel_blank_page_check( dfu_device_t *device,
-                                             const uint32_t start,
-                                             const uint32_t end ) {
+static int32_t
+__atmel_blank_page_check (dfu_device_t *device, const uint32_t start, const uint32_t end) {
     uint8_t command[6] = { 0x03, 0x01, 0x00, 0x00, 0x00, 0x00 };
     dfu_status_t status;
 
-    TRACE( "%s( %p, 0x%08x, 0x%08x )\n", __FUNCTION__, device, start, end );
+    TRACE ("%s( %p, 0x%08x, 0x%08x )\n", __FUNCTION__, device, start, end);
 
-    if( (NULL == device) ) {
-        DEBUG( "ERROR: Invalid arguments, device pointer is NULL.\n" );
+    if ((NULL == device)) {
+        DEBUG ("ERROR: Invalid arguments, device pointer is NULL.\n");
         return -1;
-    } else if ( start > end ) {
-        DEBUG( "ERROR: End address 0x%X before start address 0x%X.\n",
-                end, start );
+    } else if (start > end) {
+        DEBUG ("ERROR: End address 0x%X before start address 0x%X.\n", end, start);
         return -1;
-    } else if ( end >= ATMEL_64KB_PAGE ) {
-        DEBUG( "ERROR: Address out of 64kb (0x10000) byte page range.\n",
-                end );
+    } else if (end >= ATMEL_64KB_PAGE) {
+        DEBUG ("ERROR: Address out of 64kb (0x10000) byte page range.\n", end);
         return -1;
     }
 
@@ -769,316 +669,298 @@ static int32_t __atmel_blank_page_check( dfu_device_t *device,
     command[4] = 0xff & (end >> 8);
     command[5] = 0xff & end;
 
-    if( 6 != dfu_download(device, 6, command) ) {
-        DEBUG( "__atmel_blank_page_check DFU_DNLOAD failed.\n" );
+    if (6 != dfu_download (device, 6, command)) {
+        DEBUG ("__atmel_blank_page_check DFU_DNLOAD failed.\n");
         return -2;
     }
 
-    if( 0 != dfu_get_status(device, &status) ) {
-        DEBUG( "__atmel_blank_page_check DFU_GETSTATUS failed.\n" );
+    if (0 != dfu_get_status (device, &status)) {
+        DEBUG ("__atmel_blank_page_check DFU_GETSTATUS failed.\n");
         return -3;
     }
 
     // check status and proceed accordingly
-    if( DFU_STATUS_OK == status.bStatus ) {
-        DEBUG( "Flash region from 0x%X to 0x%X is blank.\n", start, end );
-    } else if ( DFU_STATUS_ERROR_CHECK_ERASED == status.bStatus ) {
+    if (DFU_STATUS_OK == status.bStatus) {
+        DEBUG ("Flash region from 0x%X to 0x%X is blank.\n", start, end);
+    } else if (DFU_STATUS_ERROR_CHECK_ERASED == status.bStatus) {
         // need to DFU upload to get the address
-        DEBUG( "Region is NOT bank.\n" );
+        DEBUG ("Region is NOT bank.\n");
         uint8_t addr[2] = { 0x00, 0x00 };
         int32_t retval = 0;
-        if ( 2 != dfu_upload(device, 2, addr) ) {
-            DEBUG( "__atmel_blank_page_check DFU_UPLOAD failed.\n" );
+        if (2 != dfu_upload (device, 2, addr)) {
+            DEBUG ("__atmel_blank_page_check DFU_UPLOAD failed.\n");
             return -4;
         } else {
-            retval = (int32_t) ( ( ((uint16_t) addr[0]) << 8 ) + addr[1] );
-            DEBUG( " First non-blank address in region is 0x%X.\n", retval );
+            retval = (int32_t)((((uint16_t)addr[0]) << 8) + addr[1]);
+            DEBUG (" First non-blank address in region is 0x%X.\n", retval);
             return retval + 1;
         }
     } else {
-        DEBUG( "Error: status (%s) was not OK.\n",
-            dfu_status_to_string(status.bStatus) );
-        if ( STATE_DFU_ERROR == status.bState ) {
-            dfu_clear_status( device );
-        }
+        DEBUG ("Error: status (%s) was not OK.\n", dfu_status_to_string (status.bStatus));
+        if (STATE_DFU_ERROR == status.bState) { dfu_clear_status (device); }
         return -4;
     }
     return 0;
 }
 
-int32_t atmel_blank_check( dfu_device_t *device,
-                           const uint32_t start,
-                           const uint32_t end,
-                           bool quiet ) {
-    int32_t result;                     // blank_page_check_result
-    uint32_t blank_upto = start;        // up to is not inclusive
-    uint32_t check_until;               // end address of page check
-    uint16_t current_page;              // 64kb page number
+int32_t
+atmel_blank_check (dfu_device_t *device, const uint32_t start, const uint32_t end, bool quiet) {
+    int32_t result;              // blank_page_check_result
+    uint32_t blank_upto = start; // up to is not inclusive
+    uint32_t check_until;        // end address of page check
+    uint16_t current_page;       // 64kb page number
     int32_t retval;
 
-    TRACE( "%s( %p, 0x%08X, 0x%08X )\n", __FUNCTION__, device, start, end );
+    TRACE ("%s( %p, 0x%08X, 0x%08X )\n", __FUNCTION__, device, start, end);
 
-    if( (NULL == device) ) {
-        DEBUG( "ERROR: Invalid arguments, device pointer is NULL.\n" );
+    if ((NULL == device)) {
+        DEBUG ("ERROR: Invalid arguments, device pointer is NULL.\n");
         return -1;
-    } else if ( start > end ) {
-        DEBUG( "ERROR: End address 0x%X before start address 0x%X.\n",
-                end, start );
+    } else if (start > end) {
+        DEBUG ("ERROR: End address 0x%X before start address 0x%X.\n", end, start);
         return -1;
     }
 
     // safe to call this with any type of device
-    if( 0 != atmel_select_memory_unit(device, mem_flash) ) {
-        return -2;
-    }
+    if (0 != atmel_select_memory_unit (device, mem_flash)) { return -2; }
 
-    if( !quiet ) {
-        fprintf( stderr, "Checking memory from 0x%X to 0x%X...  ",
-                start, end );
+    if (!quiet) {
+        fprintf (stderr, "Checking memory from 0x%X to 0x%X...  ", start, end);
         // from here need to go to retval on error
-        if( debug > ATMEL_DEBUG_THRESHOLD ) fprintf( stderr, "\n" );
+        if (debug > ATMEL_DEBUG_THRESHOLD) fprintf (stderr, "\n");
     }
     do {
         // want to have checks align with pages
         current_page = blank_upto / ATMEL_64KB_PAGE;
-        check_until = ( current_page + 1 ) * ATMEL_64KB_PAGE - 1;
+        check_until = (current_page + 1) * ATMEL_64KB_PAGE - 1;
         check_until = check_until > end ? end : check_until;
 
         // safe to call with any type of device (just bc end address is
         // below 0x10000 doesn't mean you are definitely on page 0)
-        if ( 0 != atmel_select_page(device, current_page) ) {
+        if (0 != atmel_select_page (device, current_page)) {
             DEBUG ("page select error.\n");
             retval = -3;
             goto error;
         }
 
         // send the 'page' address, not absolute address
-        result = __atmel_blank_page_check( device,
-                blank_upto % ATMEL_64KB_PAGE,
-                check_until % ATMEL_64KB_PAGE );
+        result = __atmel_blank_page_check (device, blank_upto % ATMEL_64KB_PAGE, check_until % ATMEL_64KB_PAGE);
 
-        if ( result == 0 ) {
-            DEBUG ( "Flash blank from 0x%X to 0x%X.\n",
-                    start, check_until );
+        if (result == 0) {
+            DEBUG ("Flash blank from 0x%X to 0x%X.\n", start, check_until);
             blank_upto = check_until + 1;
-        } else if ( result > 0 ) {
+        } else if (result > 0) {
             blank_upto = result - 1 + ATMEL_64KB_PAGE * current_page;
-            DEBUG ( "Flash NOT blank beginning at 0x%X.\n", blank_upto );
+            DEBUG ("Flash NOT blank beginning at 0x%X.\n", blank_upto);
             retval = blank_upto + 1;
             goto error;
         } else {
-            DEBUG ( "Blank check fail err %d. Flash status unknown.\n", result );
+            DEBUG ("Blank check fail err %d. Flash status unknown.\n", result);
             retval = result;
             goto error;
         }
-    } while ( blank_upto < end );
+    } while (blank_upto < end);
     retval = 0;
 
 error:
-    if( retval == 0 ) {
-        if( !quiet ) fprintf( stderr, "Empty.\n" );
-    } else if ( retval > 0 ) {
-        if( !quiet ) fprintf( stderr, "Not blank at 0x%X.\n", retval );
+    if (retval == 0) {
+        if (!quiet) fprintf (stderr, "Empty.\n");
+    } else if (retval > 0) {
+        if (!quiet) fprintf (stderr, "Not blank at 0x%X.\n", retval);
     } else {
-        if( !quiet ) fprintf( stderr, "ERROR.\n" );
+        if (!quiet) fprintf (stderr, "ERROR.\n");
     }
     return retval;
 }
 
-int32_t atmel_start_app_reset( dfu_device_t *device ) {
+int32_t
+atmel_start_app_reset (dfu_device_t *device) {
     uint8_t command[3] = { 0x04, 0x03, 0x00 };
     int32_t retval;
 
-    TRACE( "%s( %p )\n", __FUNCTION__, device );
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
 
-    if( 3 != dfu_download(device, 3, command) ) {
-        DEBUG( "dfu_download failed.\n" );
+    if (3 != dfu_download (device, 3, command)) {
+        DEBUG ("dfu_download failed.\n");
         return -1;
     }
 
-    if( 0 != (retval = dfu_download(device, 0, NULL)) ) {
-        DEBUG( "dfu_download failed (rv=%d).\n", retval );
+    if (0 != (retval = dfu_download (device, 0, NULL))) {
+        DEBUG ("dfu_download failed (rv=%d).\n", retval);
         return -2;
     }
 
     return 0;
 }
 
-int32_t atmel_start_app_noreset( dfu_device_t *device ) {
+int32_t
+atmel_start_app_noreset (dfu_device_t *device) {
     uint8_t command[5] = { 0x04, 0x03, 0x01, 0x00, 0x00 };
 
-    TRACE( "%s( %p )\n", __FUNCTION__, device );
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
 
-    if( 5 != dfu_download(device, 5, command) ) {
-        DEBUG( "dfu_download failed.\n" );
+    if (5 != dfu_download (device, 5, command)) {
+        DEBUG ("dfu_download failed.\n");
         return -1;
     }
 
-    if( 0 != dfu_download(device, 0, NULL) ) {
-        DEBUG( "dfu_download failed.\n" );
+    if (0 != dfu_download (device, 0, NULL)) {
+        DEBUG ("dfu_download failed.\n");
         return -2;
     }
 
     return 0;
 }
 
-static int32_t atmel_select_memory_unit( dfu_device_t *device,
-                                enum atmel_memory_unit_enum unit ) {
-    TRACE( "%s( %p, %d )\n", __FUNCTION__, device, unit );
+static int32_t
+atmel_select_memory_unit (dfu_device_t *device, enum atmel_memory_unit_enum unit) {
+    TRACE ("%s( %p, %d )\n", __FUNCTION__, device, unit);
 
     uint8_t command[4] = { 0x06, 0x03, 0x00, (0xFF & unit) };
     dfu_status_t status;
     char *mem_names[] = { ATMEL_MEM_UNIT_NAMES };
 
     // input parameter checks
-    if( NULL == device) {
-        DEBUG ( "ERROR: Device pointer is NULL.\n" );
+    if (NULL == device) {
+        DEBUG ("ERROR: Device pointer is NULL.\n");
         return -1;
     }
 
     // check compatiblity with various devices
-    if( !(GRP_AVR32 & device->type) ) {
-        DEBUG( "Ignore Select Memory Unit for non GRP_AVR32 device.\n" );
+    if (!(GRP_AVR32 & device->type)) {
+        DEBUG ("Ignore Select Memory Unit for non GRP_AVR32 device.\n");
         return 0;
-    } else if ( (ADC_AVR32 & device->type) && !( unit == mem_flash ||
-                                                 unit == mem_security ||
-                                                 unit == mem_config ||
-                                                 unit == mem_boot ||
-                                                 unit == mem_sig ||
-                                                 unit == mem_user ) ) {
-        DEBUG( "%d is not a valid memory unit for AVR32 devices.\n", unit );
-        fprintf( stderr, "Invalid Memory Unit Selection.\n" );
+    } else if ((ADC_AVR32 & device->type)
+               && !(unit == mem_flash || unit == mem_security || unit == mem_config || unit == mem_boot
+                    || unit == mem_sig || unit == mem_user)) {
+        DEBUG ("%d is not a valid memory unit for AVR32 devices.\n", unit);
+        fprintf (stderr, "Invalid Memory Unit Selection.\n");
         return -1;
-    } else if ( unit > mem_extdf ) {
-        DEBUG( "Valid Memory Units 0 to 0x%X, not 0x%X.\n", mem_extdf, unit );
-        fprintf( stderr, "Invalid Memory Unit Selection.\n" );
+    } else if (unit > mem_extdf) {
+        DEBUG ("Valid Memory Units 0 to 0x%X, not 0x%X.\n", mem_extdf, unit);
+        fprintf (stderr, "Invalid Memory Unit Selection.\n");
         return -1;
     }
 
     // select memory unit               below is OK bc unit < len(mem_names)
-    DEBUG( "Selecting %s memory unit.\n", mem_names[unit] );
-    if( 4 != dfu_download(device, 4, command) ) {
-        DEBUG( "atmel_select_memory_unit 0x%02X dfu_download failed.\n", unit );
+    DEBUG ("Selecting %s memory unit.\n", mem_names[unit]);
+    if (4 != dfu_download (device, 4, command)) {
+        DEBUG ("atmel_select_memory_unit 0x%02X dfu_download failed.\n", unit);
         return -2;
     }
 
     // check that memory section was selected
-    if( 0 != dfu_get_status(device, &status) ) {
-        DEBUG( "DFU_GETSTATUS failed after atmel_select_memory_unit.\n" );
+    if (0 != dfu_get_status (device, &status)) {
+        DEBUG ("DFU_GETSTATUS failed after atmel_select_memory_unit.\n");
         return -3;
     }
 
     // if error, report and clear
-    if( DFU_STATUS_OK != status.bStatus ) {
-        DEBUG( "Error: status (%s) was not OK.\n",
-            dfu_status_to_string(status.bStatus) );
-        if ( STATE_DFU_ERROR == status.bState ) {
-            dfu_clear_status( device );
-        }
+    if (DFU_STATUS_OK != status.bStatus) {
+        DEBUG ("Error: status (%s) was not OK.\n", dfu_status_to_string (status.bStatus));
+        if (STATE_DFU_ERROR == status.bState) { dfu_clear_status (device); }
         return -4;
     }
 
     return 0;
 }
 
-static int32_t atmel_select_page( dfu_device_t *device,
-                                  const uint16_t mem_page ) {
-    TRACE( "%s( %p, %u )\n", __FUNCTION__, device, mem_page );
+static int32_t
+atmel_select_page (dfu_device_t *device, const uint16_t mem_page) {
+    TRACE ("%s( %p, %u )\n", __FUNCTION__, device, mem_page);
     dfu_status_t status;
 
-    if( NULL == device ) {
-        DEBUG ( "ERROR: Device pointer is NULL.\n" );
+    if (NULL == device) {
+        DEBUG ("ERROR: Device pointer is NULL.\n");
         return -2;
     }
 
-    if ( ADC_8051 & device->type ) {
-        DEBUG( "Select page not implemented for 8051 device, ignoring.\n" );
+    if (ADC_8051 & device->type) {
+        DEBUG ("Select page not implemented for 8051 device, ignoring.\n");
         return 0;
     }
 
-    DEBUG( "Selecting page %d, address 0x%X.\n",
-            mem_page, ATMEL_64KB_PAGE * mem_page );
+    DEBUG ("Selecting page %d, address 0x%X.\n", mem_page, ATMEL_64KB_PAGE * mem_page);
 
-    if( GRP_AVR32 & device->type ) {
+    if (GRP_AVR32 & device->type) {
         uint8_t command[5] = { 0x06, 0x03, 0x01, 0x00, 0x00 };
         command[3] = 0xff & (mem_page >> 8);
         command[4] = 0xff & mem_page;
 
-        if( 5 != dfu_download(device, 5, command) ) {
-            DEBUG( "atmel_select_page DFU_DNLOAD failed.\n" );
+        if (5 != dfu_download (device, 5, command)) {
+            DEBUG ("atmel_select_page DFU_DNLOAD failed.\n");
             return -1;
         }
-    } else if( ADC_AVR == device->type ) {      // AVR but not 8051
+    } else if (ADC_AVR == device->type) { // AVR but not 8051
         uint8_t command[4] = { 0x06, 0x03, 0x00, 0x00 };
         command[3] = 0xff & mem_page;
 
-        if( 4 != dfu_download(device, 4, command) ) {
-            DEBUG( "atmel_select_page DFU_DNLOAD failed.\n" );
+        if (4 != dfu_download (device, 4, command)) {
+            DEBUG ("atmel_select_page DFU_DNLOAD failed.\n");
             return -1;
         }
     }
 
     // check that page number was set
-    if( 0 != dfu_get_status(device, &status) ) {
-        DEBUG( "atmel_select_page DFU_GETSTATUS failed.\n" );
+    if (0 != dfu_get_status (device, &status)) {
+        DEBUG ("atmel_select_page DFU_GETSTATUS failed.\n");
         return -3;
     }
 
     // if error, report and clear
-    if( DFU_STATUS_OK != status.bStatus ) {
-        DEBUG( "Error: status (%s) was not OK.\n",
-            dfu_status_to_string(status.bStatus) );
-        if ( STATE_DFU_ERROR == status.bState ) {
-            dfu_clear_status( device );
-        }
+    if (DFU_STATUS_OK != status.bStatus) {
+        DEBUG ("Error: status (%s) was not OK.\n", dfu_status_to_string (status.bStatus));
+        if (STATE_DFU_ERROR == status.bState) { dfu_clear_status (device); }
         return -4;
     }
 
     return 0;
 }
 
-int32_t atmel_user( dfu_device_t *device, intel_buffer_out_t *bout ) {
+int32_t
+atmel_user (dfu_device_t *device, intel_buffer_out_t *bout) {
     int32_t result = 0;
 
-    TRACE( "%s( %p, %p )\n", __FUNCTION__, device, bout );
+    TRACE ("%s( %p, %p )\n", __FUNCTION__, device, bout);
 
-    if( (NULL == bout) || (NULL == device ) ) {
-        DEBUG( "invalid arguments.\n" );
+    if ((NULL == bout) || (NULL == device)) {
+        DEBUG ("invalid arguments.\n");
         return -1;
     }
 
     /* Select USER page */
-    if( 0 != atmel_select_memory_unit(device, mem_user) ) {
-        DEBUG( "User Page Memory NOT selected.\n" );
+    if (0 != atmel_select_memory_unit (device, mem_user)) {
+        DEBUG ("User Page Memory NOT selected.\n");
         return -2;
     } else {
-        DEBUG( "User Page memory selected.\n" );
+        DEBUG ("User Page memory selected.\n");
     }
 
     bout->info.block_start = 0;
     bout->info.block_end = bout->info.page_size - 1;
 
-    //The user block is one flash page, so we'll just do it all in a block.
-    result = __atmel_flash_block( device, bout, false );
+    // The user block is one flash page, so we'll just do it all in a block.
+    result = __atmel_flash_block (device, bout, false);
 
-    if( result != 0 ) {
-        DEBUG( "error flashing the block: %d\n", result );
+    if (result != 0) {
+        DEBUG ("error flashing the block: %d\n", result);
         return -4;
     }
 
     return 0;
 }
 
-int32_t atmel_secure( dfu_device_t *device ) {
+int32_t
+atmel_secure (dfu_device_t *device) {
     int32_t result = 0;
     uint16_t buffer[1];
     intel_buffer_out_t bout;
-    TRACE( "%s( %p )\n", __FUNCTION__, device );
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
 
     /* Select SECURITY page */
     uint8_t command[4] = { 0x06, 0x03, 0x00, 0x02 };
-    if( 4 != dfu_download(device, 4, command) ) {
-        DEBUG( "dfu_download failed.\n" );
+    if (4 != dfu_download (device, 4, command)) {
+        DEBUG ("dfu_download failed.\n");
         return -2;
     }
 
@@ -1087,21 +969,22 @@ int32_t atmel_secure( dfu_device_t *device ) {
     bout.data = buffer;
 
     // The security block is a single byte, so we'll just do it all in a block.
-    buffer[0] = 0x01;   // Non-zero to set security fuse.
-    result = __atmel_flash_block( device, &bout, false );
+    buffer[0] = 0x01; // Non-zero to set security fuse.
+    result = __atmel_flash_block (device, &bout, false);
 
-    if( result != 0 ) {
-        DEBUG( "error flashing security fuse: %d\n", result );
+    if (result != 0) {
+        DEBUG ("error flashing security fuse: %d\n", result);
         return -4;
     }
 
     return 0;
 }
 
-int32_t atmel_getsecure( dfu_device_t *device ) {
+int32_t
+atmel_getsecure (dfu_device_t *device) {
     int32_t result = 0;
     uint8_t buffer[1];
-    TRACE( "%s( %p )\n", __FUNCTION__, device );
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
 
     intel_buffer_in_t buin;
 
@@ -1110,238 +993,202 @@ int32_t atmel_getsecure( dfu_device_t *device ) {
     buin.info.block_end = 0;
     buin.data = buffer;
 
-    dfu_clear_status( device );
+    dfu_clear_status (device);
 
     // TODO : Probably should use select_memory_unit command here
     /* Select SECURITY page */
     uint8_t command[4] = { 0x06, 0x03, 0x00, 0x02 };
-    result = dfu_download(device, 4, command);
-    if( 4 != result ) {
-        if( -EIO == result ) {
+    result = dfu_download (device, 4, command);
+    if (4 != result) {
+        if (-EIO == result) {
             /* This also happens on most access attempts
              * when the security bit is set. It may be a bug
              * in the bootloader itself.
              */
             return ATMEL_SECURE_MAYBE;
         } else {
-            DEBUG( "dfu_download failed.\n" );
+            DEBUG ("dfu_download failed.\n");
             return -1;
         }
     }
 
     // The security block is a single byte, so we'll just do it all in a block.
-    if( 0 != __atmel_read_block(device, &buin, false) ) {
-            return -2;
-    }
+    if (0 != __atmel_read_block (device, &buin, false)) { return -2; }
 
-    return( (0 == buffer[0]) ? ATMEL_SECURE_OFF : ATMEL_SECURE_ON );
+    return ((0 == buffer[0]) ? ATMEL_SECURE_OFF : ATMEL_SECURE_ON);
 }
 
-int32_t atmel_flash( dfu_device_t *device,
-                     intel_buffer_out_t *bout,
-                     const bool eeprom,
-                     const bool force,
-                     const bool quiet ) {
+int32_t
+atmel_flash (dfu_device_t *device, intel_buffer_out_t *bout, const bool eeprom, const bool force, const bool quiet) {
     uint32_t i;
-    uint32_t progress = 0;  // keep record of sent progress as bytes * 32
-    uint8_t mem_page = 0;   // tracks the current memory page
-    int32_t result = 0;     // result storage for many function calls
-    int32_t retval = -1;    // the return value for this function
+    uint32_t progress = 0; // keep record of sent progress as bytes * 32
+    uint8_t mem_page = 0;  // tracks the current memory page
+    int32_t result = 0;    // result storage for many function calls
+    int32_t retval = -1;   // the return value for this function
 
-    TRACE( "%s( %p, %p, %s, %s )\n", __FUNCTION__, device, bout,
-                    ((true == eeprom) ? "true" : "false"),
-                    ((true == quiet) ? "true" : "false") );
+    TRACE ("%s( %p, %p, %s, %s )\n", __FUNCTION__, device, bout, ((true == eeprom) ? "true" : "false"),
+           ((true == quiet) ? "true" : "false"));
 
     // check arguments
-    if( (NULL == device) || (NULL == bout) ) {
-        DEBUG( "ERROR: Invalid arguments, device/buffer pointer is NULL.\n" );
-        if( !quiet )
-            fprintf( stderr, "Program Error, use debug for more info.\n" );
+    if ((NULL == device) || (NULL == bout)) {
+        DEBUG ("ERROR: Invalid arguments, device/buffer pointer is NULL.\n");
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
         return -1;
-    } else if ( bout->info.valid_start > bout->info.valid_end ) {
-        DEBUG( "ERROR: No valid target memory, end 0x%X before start 0x%X.\n",
-                bout->info.valid_end, bout->info.valid_start );
-        if( !quiet )
-            fprintf( stderr, "Program Error, use debug for more info.\n" );
+    } else if (bout->info.valid_start > bout->info.valid_end) {
+        DEBUG ("ERROR: No valid target memory, end 0x%X before start 0x%X.\n", bout->info.valid_end,
+               bout->info.valid_start);
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
         return -1;
     }
 
     // for each page with data, fill unassigned values on the page with 0xFF
     // bout->data[0] always aligns with a flash page boundary irrespective
     // of where valid_start is located
-    if( 0 != intel_flash_prep_buffer( bout ) ) {
-        if( !quiet )
-            fprintf( stderr, "Program Error, use debug for more info.\n" );
+    if (0 != intel_flash_prep_buffer (bout)) {
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
         return -2;
     }
 
     // determine the limits of where actual data resides in the buffer
     bout->info.data_start = UINT32_MAX;
-    for( i = 0; i < bout->info.total_size; i++ ) {
-        if( bout->data[i] <= UINT8_MAX ) {
+    for (i = 0; i < bout->info.total_size; i++) {
+        if (bout->data[i] <= UINT8_MAX) {
             bout->info.data_end = i;
-            if (bout->info.data_start == UINT32_MAX)
-                bout->info.data_start = i;
+            if (bout->info.data_start == UINT32_MAX) bout->info.data_start = i;
         }
     }
 
     // debug info about data limits
-    DEBUG("Flash available from 0x%X to 0x%X (64kB p. %u to %u), 0x%X bytes.\n",
-            bout->info.valid_start, bout->info.valid_end,
-            bout->info.valid_start / ATMEL_64KB_PAGE,
-            bout->info.valid_end / ATMEL_64KB_PAGE,
-            bout->info.valid_end - bout->info.valid_start + 1); // bytes inclusive so +1
-    DEBUG("Data start @ 0x%X: 64kB p %u; %uB p 0x%X + 0x%X offset.\n",
-            bout->info.data_start, bout->info.data_start / ATMEL_64KB_PAGE,
-            bout->info.page_size, bout->info.data_start / bout->info.page_size,
-            bout->info.data_start % bout->info.page_size);
-    DEBUG("Data end @ 0x%X: 64kB p %u; %uB p 0x%X + 0x%X offset.\n",
-            bout->info.data_end, bout->info.data_end / ATMEL_64KB_PAGE,
-            bout->info.page_size, bout->info.data_end / bout->info.page_size,
-            bout->info.data_end % bout->info.page_size);
-    DEBUG("Totals: 0x%X bytes, %u %uB pages, %u 64kB byte pages.\n",
-            bout->info.data_end - bout->info.data_start + 1,
-            bout->info.data_end/bout->info.page_size - bout->info.data_start/bout->info.page_size + 1,
-            bout->info.page_size,
-            bout->info.data_end/ATMEL_64KB_PAGE - bout->info.data_start/ATMEL_64KB_PAGE + 1 );
+    DEBUG ("Flash available from 0x%X to 0x%X (64kB p. %u to %u), 0x%X bytes.\n", bout->info.valid_start,
+           bout->info.valid_end, bout->info.valid_start / ATMEL_64KB_PAGE, bout->info.valid_end / ATMEL_64KB_PAGE,
+           bout->info.valid_end - bout->info.valid_start + 1); // bytes inclusive so +1
+    DEBUG ("Data start @ 0x%X: 64kB p %u; %uB p 0x%X + 0x%X offset.\n", bout->info.data_start,
+           bout->info.data_start / ATMEL_64KB_PAGE, bout->info.page_size, bout->info.data_start / bout->info.page_size,
+           bout->info.data_start % bout->info.page_size);
+    DEBUG ("Data end @ 0x%X: 64kB p %u; %uB p 0x%X + 0x%X offset.\n", bout->info.data_end,
+           bout->info.data_end / ATMEL_64KB_PAGE, bout->info.page_size, bout->info.data_end / bout->info.page_size,
+           bout->info.data_end % bout->info.page_size);
+    DEBUG ("Totals: 0x%X bytes, %u %uB pages, %u 64kB byte pages.\n", bout->info.data_end - bout->info.data_start + 1,
+           bout->info.data_end / bout->info.page_size - bout->info.data_start / bout->info.page_size + 1,
+           bout->info.page_size, bout->info.data_end / ATMEL_64KB_PAGE - bout->info.data_start / ATMEL_64KB_PAGE + 1);
 
     // more error checking
-    if( (bout->info.data_start < bout->info.valid_start) ||
-            (bout->info.data_end > bout->info.valid_end) ) {
-        DEBUG( "ERROR: Data exists outside of the valid target flash region.\n" );
-        if( !quiet )
-            fprintf( stderr, "Hex file error, use debug for more info.\n" );
+    if ((bout->info.data_start < bout->info.valid_start) || (bout->info.data_end > bout->info.valid_end)) {
+        DEBUG ("ERROR: Data exists outside of the valid target flash region.\n");
+        if (!quiet) fprintf (stderr, "Hex file error, use debug for more info.\n");
         return -1;
-    } else if( bout->info.data_start == UINT32_MAX ) {
-        DEBUG( "ERROR: No valid data to flash.\n" );
-        if( !quiet )
-            fprintf( stderr, "Hex file error, use debug for more info.\n" );
+    } else if (bout->info.data_start == UINT32_MAX) {
+        DEBUG ("ERROR: No valid data to flash.\n");
+        if (!quiet) fprintf (stderr, "Hex file error, use debug for more info.\n");
         return -1;
-    } else if( !force && 0 != (result = atmel_blank_check(device,
-                    bout->info.data_start, bout->info.data_end, quiet)) ) {
-        if ( !quiet )
-            fprintf( stderr,
-                    "The target memory for the program is not blank.\n"
-                    "Use --force flag to override this error check.\n");
-        DEBUG("The target memory is not blank.\n");
+    } else if (!force
+               && 0 != (result = atmel_blank_check (device, bout->info.data_start, bout->info.data_end, quiet))) {
+        if (!quiet)
+            fprintf (stderr, "The target memory for the program is not blank.\n"
+                             "Use --force flag to override this error check.\n");
+        DEBUG ("The target memory is not blank.\n");
         return -1;
     }
 
     // select eeprom/flash as the desired memory target, safe for non GRP_AVR32
     mem_page = eeprom ? mem_eeprom : mem_flash;
-    if( 0 != atmel_select_memory_unit(device, mem_page) ) {
+    if (0 != atmel_select_memory_unit (device, mem_page)) {
         DEBUG ("Error selecting memory unit.\n");
-        if( !quiet )
-            fprintf( stderr, "Memory access error, use debug for more info.\n" );
+        if (!quiet) fprintf (stderr, "Memory access error, use debug for more info.\n");
         return -2;
     }
 
-    if( !quiet ) {
-        if( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
+    if (!quiet) {
+        if (debug <= ATMEL_DEBUG_THRESHOLD && isatty (2)) {
             // NOTE: from here on we need to run finally block
-            fprintf( stderr, PROGRESS_METER );
+            fprintf (stderr, PROGRESS_METER);
         }
-        fprintf( stderr, "Programming 0x%X bytes...\n",
-                bout->info.data_end - bout->info.data_start + 1 );
-        if( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
+        fprintf (stderr, "Programming 0x%X bytes...\n", bout->info.data_end - bout->info.data_start + 1);
+        if (debug <= ATMEL_DEBUG_THRESHOLD && isatty (2)) {
             // NOTE: from here on we need to run finally block
-            fprintf( stderr, PROGRESS_START );
+            fprintf (stderr, PROGRESS_START);
         }
     }
 
     // program the data
     bout->info.block_start = bout->info.data_start;
     mem_page = bout->info.block_start / ATMEL_64KB_PAGE;
-    if( 0 != (result = atmel_select_page( device, mem_page )) ) {
-        DEBUG( "ERROR selecting 64kB page %d.\n", result );
+    if (0 != (result = atmel_select_page (device, mem_page))) {
+        DEBUG ("ERROR selecting 64kB page %d.\n", result);
         retval = -3;
         goto finally;
     }
 
     while (bout->info.block_start <= bout->info.data_end) {
         // select the memory page if needed (safe for non GRP_AVR32)
-        if ( bout->info.block_start / ATMEL_64KB_PAGE != mem_page ) {
+        if (bout->info.block_start / ATMEL_64KB_PAGE != mem_page) {
             mem_page = bout->info.block_start / ATMEL_64KB_PAGE;
-            if( 0 != (result = atmel_select_page( device, mem_page )) ) {
-                DEBUG( "ERROR selecting 64kB page %d.\n", result );
+            if (0 != (result = atmel_select_page (device, mem_page))) {
+                DEBUG ("ERROR selecting 64kB page %d.\n", result);
                 retval = -3;
                 goto finally;
             }
         }
 
         // find end address (info.block_end) for data section to write
-        for(bout->info.block_end = bout->info.block_start;
-                bout->info.block_end <= bout->info.data_end;
-                bout->info.block_end++) {
+        for (bout->info.block_end = bout->info.block_start; bout->info.block_end <= bout->info.data_end;
+             bout->info.block_end++) {
             // check if the current value is valid
-            if( bout->data[bout->info.block_end] > UINT8_MAX ) break;
+            if (bout->data[bout->info.block_end] > UINT8_MAX) break;
             // check if the current data packet is too big
-            if( (bout->info.block_end - bout->info.block_start + 1) > ATMEL_MAX_TRANSFER_SIZE ) break;
+            if ((bout->info.block_end - bout->info.block_start + 1) > ATMEL_MAX_TRANSFER_SIZE) break;
             // check if the current data value is outside of the 64kB flash page
-            if( bout->info.block_end / ATMEL_64KB_PAGE - mem_page ) break;
+            if (bout->info.block_end / ATMEL_64KB_PAGE - mem_page) break;
         }
         bout->info.block_end--; // bout->info.block_end was one step beyond the last data value to flash
 
         // write the data
-        DEBUG("Program data block: 0x%X to 0x%X (p. %u), 0x%X bytes.\n",
-                bout->info.block_start, bout->info.block_end,
-                bout->info.block_end / ATMEL_64KB_PAGE,
-                bout->info.block_end - bout->info.block_start + 1);
-        result = __atmel_flash_block( device, bout, eeprom );
-        if( 0 != result ) {
-            DEBUG( "Error flashing the block: err %d.\n", result );
+        DEBUG ("Program data block: 0x%X to 0x%X (p. %u), 0x%X bytes.\n", bout->info.block_start, bout->info.block_end,
+               bout->info.block_end / ATMEL_64KB_PAGE, bout->info.block_end - bout->info.block_start + 1);
+        result = __atmel_flash_block (device, bout, eeprom);
+        if (0 != result) {
+            DEBUG ("Error flashing the block: err %d.\n", result);
             retval = -4;
             goto finally;
         }
 
         // increment bout->info.block_start to the next valid address
-        for(bout->info.block_start = bout->info.block_end + 1;
-                bout->info.block_start <= bout->info.data_end;
-                bout->info.block_start++) {
-            if( (bout->data[bout->info.block_start] <= UINT8_MAX) ) break;
+        for (bout->info.block_start = bout->info.block_end + 1; bout->info.block_start <= bout->info.data_end;
+             bout->info.block_start++) {
+            if ((bout->data[bout->info.block_start] <= UINT8_MAX)) break;
         } // bout->info.block_start is now on the first valid data for the next segment
 
         // display progress in 32 increments (if not hidden)
-        if ( !quiet ) __print_progress( &bout->info, &progress );
+        if (!quiet) __print_progress (&bout->info, &progress);
     }
     retval = 0;
 
 finally:
-    if ( !quiet ) {
-        if( 0 == retval ) {
-            if ( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
-                fprintf( stderr, PROGRESS_END );
-            }
-            fprintf( stderr, "Success\n" );
+    if (!quiet) {
+        if (0 == retval) {
+            if (debug <= ATMEL_DEBUG_THRESHOLD && isatty (2)) { fprintf (stderr, PROGRESS_END); }
+            fprintf (stderr, "Success\n");
         } else {
-            if ( debug <= ATMEL_DEBUG_THRESHOLD && isatty(2) ) {
-                fprintf( stderr, PROGRESS_ERROR );
-            }
-            fprintf( stderr, "ERROR\n" );
-            if( retval==-3 )
-                fprintf( stderr,
-                        "Memory access error, use debug for more info.\n" );
-            else if( retval==-4 )
-                fprintf( stderr,
-                        "Memory write error, use debug for more info.\n" );
+            if (debug <= ATMEL_DEBUG_THRESHOLD && isatty (2)) { fprintf (stderr, PROGRESS_ERROR); }
+            fprintf (stderr, "ERROR\n");
+            if (retval == -3)
+                fprintf (stderr, "Memory access error, use debug for more info.\n");
+            else if (retval == -4)
+                fprintf (stderr, "Memory write error, use debug for more info.\n");
         }
     }
 
     return retval;
 }
 
-static void atmel_flash_populate_footer( uint8_t *message, uint8_t *footer,
-                                         const uint16_t vendorId,
-                                         const uint16_t productId,
-                                         const uint16_t bcdFirmware ) {
+static void
+atmel_flash_populate_footer (uint8_t *message, uint8_t *footer, const uint16_t vendorId, const uint16_t productId,
+                             const uint16_t bcdFirmware) {
     int32_t crc;
 
-    TRACE( "%s( %p, %p, %u, %u, %u )\n", __FUNCTION__, message, footer,
-           vendorId, productId, bcdFirmware );
+    TRACE ("%s( %p, %p, %u, %u, %u )\n", __FUNCTION__, message, footer, vendorId, productId, bcdFirmware);
 
-    if( (NULL == message) || (NULL == footer) ) {
-        return;
-    }
+    if ((NULL == message) || (NULL == footer)) { return; }
 
     /* TODO: Calculate the message CRC */
     crc = 0;
@@ -1377,20 +1224,15 @@ static void atmel_flash_populate_footer( uint8_t *message, uint8_t *footer,
     footer[15] = 0xff & bcdFirmware;
 }
 
-static void atmel_flash_populate_header( uint8_t *header,
-                                         const uint32_t start,
-                                         const uint32_t end,
-                                         const bool eeprom ) {
+static void
+atmel_flash_populate_header (uint8_t *header, const uint32_t start, const uint32_t end, const bool eeprom) {
 
-    TRACE( "%s( %p, 0x%X, 0x%X, %s )\n", __FUNCTION__, header, start,
-           end, ((true == eeprom) ? "true" : "false") );
+    TRACE ("%s( %p, 0x%X, 0x%X, %s )\n", __FUNCTION__, header, start, end, ((true == eeprom) ? "true" : "false"));
 
-    if( NULL == header ) {
-        return;
-    }
+    if (NULL == header) { return; }
 
     /* Command Identifier */
-    header[0] = 0x01;   /* ld_prog_start */
+    header[0] = 0x01; /* ld_prog_start */
 
     /* data[0] */
     header[1] = ((true == eeprom) ? 0x01 : 0x00);
@@ -1404,9 +1246,8 @@ static void atmel_flash_populate_header( uint8_t *header,
     header[5] = 0xff & end;
 }
 
-static int32_t __atmel_flash_block( dfu_device_t *device,
-                                    intel_buffer_out_t *bout,
-                                    const bool eeprom ) {
+static int32_t
+__atmel_flash_block (dfu_device_t *device, intel_buffer_out_t *bout, const bool eeprom) {
     // from doc7618, AT90 / ATmega app note protocol:
     const size_t length = bout->info.block_end - bout->info.block_start + 1;
     uint8_t message[ATMEL_MAX_FLASH_BUFFER_SIZE];
@@ -1417,30 +1258,27 @@ static int32_t __atmel_flash_block( dfu_device_t *device,
     int32_t result;
     dfu_status_t status;
     int32_t i;
-    size_t control_block_size;  /* USB control block size */
+    size_t control_block_size; /* USB control block size */
     size_t alignment;
 
-    TRACE( "%s( %p, %p, %s )\n", __FUNCTION__, device, bout,
-                            ((true == eeprom) ? "true" : "false") );
+    TRACE ("%s( %p, %p, %s )\n", __FUNCTION__, device, bout, ((true == eeprom) ? "true" : "false"));
 
     // check input args
-    if( (NULL == device) || (NULL == bout) ) {
-        DEBUG( "ERROR: Invalid arguments, device/buffer pointer is NULL.\n" );
+    if ((NULL == device) || (NULL == bout)) {
+        DEBUG ("ERROR: Invalid arguments, device/buffer pointer is NULL.\n");
         return -1;
-    } else if ( bout->info.block_start > bout->info.block_end ) {
-        DEBUG( "ERROR: End address 0x%X before start address 0x%X.\n",
-                bout->info.block_end, bout->info.block_start );
+    } else if (bout->info.block_start > bout->info.block_end) {
+        DEBUG ("ERROR: End address 0x%X before start address 0x%X.\n", bout->info.block_end, bout->info.block_start);
         return -1;
-    } else if ( length > ATMEL_MAX_TRANSFER_SIZE ) {
-        DEBUG( "ERROR: 0x%X byte message > MAX TRANSFER SIZE (0x%X).\n",
-                length, ATMEL_MAX_TRANSFER_SIZE );
+    } else if (length > ATMEL_MAX_TRANSFER_SIZE) {
+        DEBUG ("ERROR: 0x%X byte message > MAX TRANSFER SIZE (0x%X).\n", length, ATMEL_MAX_TRANSFER_SIZE);
         return -1;
     }
 
     // 0 out the message
-    memset( message, 0, ATMEL_MAX_FLASH_BUFFER_SIZE );
+    memset (message, 0, ATMEL_MAX_FLASH_BUFFER_SIZE);
 
-    if( GRP_AVR32 & device->type ) {
+    if (GRP_AVR32 & device->type) {
         control_block_size = ATMEL_AVR32_CONTROL_BLOCK_SIZE;
         alignment = bout->info.block_start % ATMEL_AVR32_CONTROL_BLOCK_SIZE;
     } else {
@@ -1449,80 +1287,71 @@ static int32_t __atmel_flash_block( dfu_device_t *device,
     }
 
     header = &message[0];
-    data   = &message[control_block_size + alignment];
+    data = &message[control_block_size + alignment];
     footer = &data[length];
 
-    atmel_flash_populate_header( header,
-            bout->info.block_start % ATMEL_64KB_PAGE,
-            bout->info.block_end % ATMEL_64KB_PAGE,
-            eeprom );
+    atmel_flash_populate_header (header, bout->info.block_start % ATMEL_64KB_PAGE,
+                                 bout->info.block_end % ATMEL_64KB_PAGE, eeprom);
     /* for programming flash or eeprom for xmega or avr32, header[1] = 0x00 */
     /* for programming eeprom, memory was selected in atmel_flash */
-    if( ADC_XMEGA & device->type ) {
-	header[1] = 0x00;
-    }
+    if (ADC_XMEGA & device->type) { header[1] = 0x00; }
 
     // Copy the data
-    for( i = 0; i < length; i++ ) {
-        data[i] = (uint8_t) bout->data[bout->info.block_start + i];
-    }
+    for (i = 0; i < length; i++) { data[i] = (uint8_t)bout->data[bout->info.block_start + i]; }
 
-    atmel_flash_populate_footer( message, footer, 0xffff, 0xffff, 0xffff );
+    atmel_flash_populate_footer (message, footer, 0xffff, 0xffff, 0xffff);
 
-    message_length = ((size_t) (footer - header)) + ATMEL_FOOTER_SIZE;
+    message_length = ((size_t)(footer - header)) + ATMEL_FOOTER_SIZE;
 
-    result = dfu_download( device, message_length, message );
+    result = dfu_download (device, message_length, message);
 
-    if( message_length != result ) {
-        if( -EPIPE == result ) {
+    if (message_length != result) {
+        if (-EPIPE == result) {
             /* The control pipe stalled - this is an error
              * caused by the device saying "you can't do that"
              * which means the device is write protected.
              */
-            fprintf( stderr, "Device is write protected.\n" );
-            dfu_clear_status( device );
+            fprintf (stderr, "Device is write protected.\n");
+            dfu_clear_status (device);
         } else {
-            DEBUG( "atmel_flash: flash data dfu_download failed.\n" );
-            DEBUG( "Expected message length of %d, got %d.\n",
-                    message_length, result );
+            DEBUG ("atmel_flash: flash data dfu_download failed.\n");
+            DEBUG ("Expected message length of %d, got %d.\n", message_length, result);
         }
         return -2;
     }
 
     // check status
-    if( 0 != dfu_get_status(device, &status) ) {
-        DEBUG( "dfu_get_status failed.\n" );
+    if (0 != dfu_get_status (device, &status)) {
+        DEBUG ("dfu_get_status failed.\n");
         return -3;
     }
 
-    if( DFU_STATUS_OK == status.bStatus ) {
-        DEBUG( "Page write success.\n" );
+    if (DFU_STATUS_OK == status.bStatus) {
+        DEBUG ("Page write success.\n");
     } else {
-        DEBUG( "Page write not unsuccessful (err %s).\n",
-               dfu_status_to_string(status.bStatus) );
-        if ( STATE_DFU_ERROR == status.bState ) {
-            dfu_clear_status( device );
-        }
-        return (int32_t) status.bStatus;
+        DEBUG ("Page write not unsuccessful (err %s).\n", dfu_status_to_string (status.bStatus));
+        if (STATE_DFU_ERROR == status.bState) { dfu_clear_status (device); }
+        return (int32_t)status.bStatus;
     }
     return 0;
 }
 
-void atmel_print_device_info( FILE *stream, atmel_device_info_t *info ) {
-    fprintf( stream, "%18s: 0x%04x - %d\n", "Bootloader Version", info->bootloaderVersion, info->bootloaderVersion );
-    fprintf( stream, "%18s: 0x%04x - %d\n", "Device boot ID 1", info->bootID1, info->bootID1 );
-    fprintf( stream, "%18s: 0x%04x - %d\n", "Device boot ID 2", info->bootID2, info->bootID2 );
+void
+atmel_print_device_info (FILE *stream, atmel_device_info_t *info) {
+    fprintf (stream, "%18s: 0x%04x - %d\n", "Bootloader Version", info->bootloaderVersion, info->bootloaderVersion);
+    fprintf (stream, "%18s: 0x%04x - %d\n", "Device boot ID 1", info->bootID1, info->bootID1);
+    fprintf (stream, "%18s: 0x%04x - %d\n", "Device boot ID 2", info->bootID2, info->bootID2);
 
-    if( /* device is 8051 based */ 0 ) {
-        fprintf( stream, "%18s: 0x%04x - %d\n", "Device BSB", info->bsb, info->bsb );
-        fprintf( stream, "%18s: 0x%04x - %d\n", "Device SBV", info->sbv, info->sbv );
-        fprintf( stream, "%18s: 0x%04x - %d\n", "Device SSB", info->ssb, info->ssb );
-        fprintf( stream, "%18s: 0x%04x - %d\n", "Device EB", info->eb, info->eb );
+    if (/* device is 8051 based */ 0) {
+        fprintf (stream, "%18s: 0x%04x - %d\n", "Device BSB", info->bsb, info->bsb);
+        fprintf (stream, "%18s: 0x%04x - %d\n", "Device SBV", info->sbv, info->sbv);
+        fprintf (stream, "%18s: 0x%04x - %d\n", "Device SSB", info->ssb, info->ssb);
+        fprintf (stream, "%18s: 0x%04x - %d\n", "Device EB", info->eb, info->eb);
     }
 
-    fprintf( stream, "%18s: 0x%04x - %d\n", "Manufacturer Code", info->manufacturerCode, info->manufacturerCode );
-    fprintf( stream, "%18s: 0x%04x - %d\n", "Family Code", info->familyCode, info->familyCode );
-    fprintf( stream, "%18s: 0x%04x - %d\n", "Product Name", info->productName, info->productName );
-    fprintf( stream, "%18s: 0x%04x - %d\n", "Product Revision", info->productRevision, info->productRevision );
-    fprintf( stream, "%18s: 0x%04x - %d\n", "HWB", info->hsb, info->hsb );
+    fprintf (stream, "%18s: 0x%04x - %d\n", "Manufacturer Code", info->manufacturerCode, info->manufacturerCode);
+    fprintf (stream, "%18s: 0x%04x - %d\n", "Family Code", info->familyCode, info->familyCode);
+    fprintf (stream, "%18s: 0x%04x - %d\n", "Product Name", info->productName, info->productName);
+    fprintf (stream, "%18s: 0x%04x - %d\n", "Product Revision", info->productRevision, info->productRevision);
+    fprintf (stream, "%18s: 0x%04x - %d\n", "HWB", info->hsb, info->hsb);
 }

--- a/src/atmel.h
+++ b/src/atmel.h
@@ -21,71 +21,84 @@
 #ifndef __ATMEL_H__
 #define __ATMEL_H__
 
-#include <stdio.h>
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
 
 #include "dfu-device.h"
 #include "intel_hex.h"
 
 #define ATMEL_USER_PAGE_OFFSET 0x80800000
 
-#define ATMEL_ERASE_BLOCK_0     0
-#define ATMEL_ERASE_BLOCK_1     1
-#define ATMEL_ERASE_BLOCK_2     2
-#define ATMEL_ERASE_BLOCK_3     3
-#define ATMEL_ERASE_ALL         4
+#define ATMEL_ERASE_BLOCK_0 0
+#define ATMEL_ERASE_BLOCK_1 1
+#define ATMEL_ERASE_BLOCK_2 2
+#define ATMEL_ERASE_BLOCK_3 3
+#define ATMEL_ERASE_ALL     4
 
-#define ATMEL_SET_CONFIG_BSB    0
-#define ATMEL_SET_CONFIG_SBV    1
-#define ATMEL_SET_CONFIG_SSB    2
-#define ATMEL_SET_CONFIG_EB     3
-#define ATMEL_SET_CONFIG_HSB    4
+#define ATMEL_SET_CONFIG_BSB 0
+#define ATMEL_SET_CONFIG_SBV 1
+#define ATMEL_SET_CONFIG_SSB 2
+#define ATMEL_SET_CONFIG_EB  3
+#define ATMEL_SET_CONFIG_HSB 4
 
-#define ATMEL_SECURE_OFF        0       // Security bit is cleared
-#define ATMEL_SECURE_ON         1       // Security bit is set
-#define ATMEL_SECURE_MAYBE      2       // Call to check security bit failed
+#define ATMEL_SECURE_OFF   0 // Security bit is cleared
+#define ATMEL_SECURE_ON    1 // Security bit is set
+#define ATMEL_SECURE_MAYBE 2 // Call to check security bit failed
 
 /* All values are valid if in the range of 0-255, invalid otherwise */
 typedef struct {
-    int16_t bootloaderVersion;  // Bootloader Version
-    int16_t bootID1;            // Device boot ID 1
-    int16_t bootID2;            // Device boot ID 2
-    int16_t bsb;                // Boot Status Byte
-    int16_t sbv;                // Software Boot Vector
-    int16_t ssb;                // Software Security Byte
-    int16_t eb;                 // Extra Byte
-    int16_t manufacturerCode;   // Manufacturer Code
-    int16_t familyCode;         // Family Code
-    int16_t productName;        // Product Name
-    int16_t productRevision;    // Product Revision
-    int16_t hsb;                // Hardware Security Byte
+    int16_t bootloaderVersion; // Bootloader Version
+    int16_t bootID1;           // Device boot ID 1
+    int16_t bootID2;           // Device boot ID 2
+    int16_t bsb;               // Boot Status Byte
+    int16_t sbv;               // Software Boot Vector
+    int16_t ssb;               // Software Security Byte
+    int16_t eb;                // Extra Byte
+    int16_t manufacturerCode;  // Manufacturer Code
+    int16_t familyCode;        // Family Code
+    int16_t productName;       // Product Name
+    int16_t productRevision;   // Product Revision
+    int16_t hsb;               // Hardware Security Byte
 } atmel_device_info_t;
 
 typedef struct {
-    int32_t lock;               // Locked region
-    int32_t epfl;               // External Privileged fetch lock
-    int32_t bootprot;           // Bootloader protected area
-    int32_t bodlevel;           // Brown-out detector trigger level
-    int32_t bodhyst;            // BOD hysteresis enable
-    int32_t boden;              // BOD enable state
-    int32_t isp_bod_en;         // Tells the ISP to enable BOD
-    int32_t isp_io_cond_en;     // ISP uses User page to launch bootloader
-    int32_t isp_force;          // Start the ISP no matter what
+    int32_t lock;           // Locked region
+    int32_t epfl;           // External Privileged fetch lock
+    int32_t bootprot;       // Bootloader protected area
+    int32_t bodlevel;       // Brown-out detector trigger level
+    int32_t bodhyst;        // BOD hysteresis enable
+    int32_t boden;          // BOD enable state
+    int32_t isp_bod_en;     // Tells the ISP to enable BOD
+    int32_t isp_io_cond_en; // ISP uses User page to launch bootloader
+    int32_t isp_force;      // Start the ISP no matter what
 } atmel_avr32_fuses_t;
 
+enum atmel_memory_unit_enum {
+    mem_flash,
+    mem_eeprom,
+    mem_security,
+    mem_config,
+    mem_boot,
+    mem_sig,
+    mem_user,
+    mem_ram,
+    mem_ext0,
+    mem_ext1,
+    mem_ext2,
+    mem_ext3,
+    mem_ext,
+    mem_ext5,
+    mem_ext6,
+    mem_ext7,
+    mem_extdf
+};
 
-enum atmel_memory_unit_enum { mem_flash, mem_eeprom, mem_security, mem_config,
-    mem_boot, mem_sig, mem_user, mem_ram, mem_ext0, mem_ext1, mem_ext2,
-    mem_ext3, mem_ext, mem_ext5, mem_ext6, mem_ext7, mem_extdf };
+#define ATMEL_MEM_UNIT_NAMES                                                                                           \
+    "flash", "eeprom", "security", "config", "bootloader", "signature", "user", "int_ram", "ext_cs0", "ext_cs1",       \
+        "ext_cs2", "ext_cs3", "ext_cs4", "ext_cs5", "ext_cs6", "ext_cs7", "ext_df"
 
-#define ATMEL_MEM_UNIT_NAMES "flash", "eeprom", "security", "config", \
-    "bootloader", "signature", "user", "int_ram", "ext_cs0", "ext_cs1", \
-    "ext_cs2", "ext_cs3", "ext_cs4", "ext_cs5", "ext_cs6", "ext_cs7", "ext_df"
-
-
-int32_t atmel_read_config( dfu_device_t *device,
-                           atmel_device_info_t *info );
+int32_t atmel_read_config (dfu_device_t *device, atmel_device_info_t *info);
 /*  atmel_read_config reads in all of the configuration and Manufacturer
  *  Information into the atmel_device_info data structure for easier use later.
  *
@@ -95,12 +108,9 @@ int32_t atmel_read_config( dfu_device_t *device,
  *  returns 0 if successful, < 0 if not
  */
 
-int32_t atmel_read_fuses( dfu_device_t *device,
-                          atmel_avr32_fuses_t * info );
+int32_t atmel_read_fuses (dfu_device_t *device, atmel_avr32_fuses_t *info);
 
-int32_t atmel_erase_flash( dfu_device_t *device,
-                           const uint8_t mode,
-                           bool quiet );
+int32_t atmel_erase_flash (dfu_device_t *device, const uint8_t mode, bool quiet);
 /*  atmel_erase_flash
  *  device    - the usb_dev_handle to communicate with
  *  mode      - the mode to use when erasing flash
@@ -113,51 +123,38 @@ int32_t atmel_erase_flash( dfu_device_t *device,
  *  returns status DFU_STATUS_OK if ok, anything else on error
  */
 
-int32_t atmel_set_fuse( dfu_device_t *device,
-                          const uint8_t property,
-                          const uint32_t value );
+int32_t atmel_set_fuse (dfu_device_t *device, const uint8_t property, const uint32_t value);
 
-int32_t atmel_set_config( dfu_device_t *device,
-                          const uint8_t property,
-                          const uint8_t value );
+int32_t atmel_set_config (dfu_device_t *device, const uint8_t property, const uint8_t value);
 
-int32_t atmel_read_flash( dfu_device_t *device,
-                          intel_buffer_in_t *buin,
-                          uint8_t mem_segment,
-                          const bool quiet);
+int32_t atmel_read_flash (dfu_device_t *device, intel_buffer_in_t *buin, uint8_t mem_segment, const bool quiet);
 /* read the flash from buin->info.data_start to data_end and place
  * in buin.data. mem_segment is the segment of memory from the
  * atmel_memory_unit_enum.
  */
 
-int32_t atmel_blank_check( dfu_device_t *device,
-                           const uint32_t start,
-                           const uint32_t end,
-                           bool quiet );
+int32_t atmel_blank_check (dfu_device_t *device, const uint32_t start, const uint32_t end, bool quiet);
 /* check if memory between start byte and end byte (inclusive) is blank
  * returns 0 for success, < 0 for communication errors, > 0 for not blank
  */
 
-int32_t atmel_start_app_reset( dfu_device_t *device );
+int32_t atmel_start_app_reset (dfu_device_t *device);
 /* Reset the processor and start application.
  * This is done internally by forcing a watchdog reset.
  * Depending on fuse settings this may go straight back into the bootloader.
  */
 
-int32_t atmel_start_app_noreset( dfu_device_t *device );
+int32_t atmel_start_app_noreset (dfu_device_t *device);
 /* Start the app by jumping to the start of the app area.
  * This does not do a true device reset.
  */
 
-int32_t atmel_secure( dfu_device_t *device );
+int32_t atmel_secure (dfu_device_t *device);
 
-int32_t atmel_getsecure( dfu_device_t *device );
+int32_t atmel_getsecure (dfu_device_t *device);
 
-int32_t atmel_flash( dfu_device_t *device,
-                     intel_buffer_out_t *bout,
-                     const bool eeprom,
-                     const bool force,
-                     const bool hide_progress );
+int32_t atmel_flash (dfu_device_t *device, intel_buffer_out_t *bout, const bool eeprom, const bool force,
+                     const bool hide_progress);
 /* Flash data from the buffer to the main program memory on the device.
  * buffer contains the data to flash where buffer[0] is aligned with memory
  * address zero (which could be inside the bootloader and unavailable).
@@ -168,8 +165,7 @@ int32_t atmel_flash( dfu_device_t *device,
  * hide_progress bool sets whether to display progress
  */
 
-int32_t atmel_user( dfu_device_t *device,
-                    intel_buffer_out_t *bout );
+int32_t atmel_user (dfu_device_t *device, intel_buffer_out_t *bout);
 /* Flash data to the user page.  Provide the buffer and the size of
  * flash pages for the device (this is the size of the user page).
  * Note that only the entire user page can be flashed because it is
@@ -177,6 +173,6 @@ int32_t atmel_user( dfu_device_t *device,
  * space (start at zero and contain page_size bytes).
  */
 
-void atmel_print_device_info( FILE *stream, atmel_device_info_t *info );
+void atmel_print_device_info (FILE *stream, atmel_device_info_t *info);
 
 #endif

--- a/src/commands.c
+++ b/src/commands.c
@@ -18,108 +18,96 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <stdio.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 
-#include "config.h"
-#include "commands.h"
 #include "arguments.h"
+#include "atmel.h"
+#include "commands.h"
+#include "config.h"
 #include "intel_hex.h"
 #include "stm32.h"
-#include "atmel.h"
 #include "util.h"
 
 #define COMMAND_DEBUG_THRESHOLD 40
 
-#define DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
-                               COMMAND_DEBUG_THRESHOLD, __VA_ARGS__ )
+#define DEBUG(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, COMMAND_DEBUG_THRESHOLD, __VA_ARGS__)
 
 // ________  P R O T O T Y P E S  _______________________________
-static int32_t execute_validate( dfu_device_t *device,
-                                 intel_buffer_out_t *bout,
-                                 uint8_t mem_segment,
-                                 bool quiet,
+static int32_t execute_validate (dfu_device_t *device, intel_buffer_out_t *bout, uint8_t mem_segment, bool quiet,
                                  bool ignore_outside);
 /* provide an out buffer to validate and whether this is from
  * flash or eeprom data sections, also wether you want it quiet
  */
 
 // ________  F U N C T I O N S  _______________________________
-static void security_check( dfu_device_t *device ) {
-    if( ADC_AVR32 == device->type ) {
+static void
+security_check (dfu_device_t *device) {
+    if (ADC_AVR32 == device->type) {
         // Get security bit state for AVR32.
-        device->security_bit_state = atmel_getsecure( device );
-        DEBUG( "Security bit check returned %d.\n", device->security_bit_state );
+        device->security_bit_state = atmel_getsecure (device);
+        DEBUG ("Security bit check returned %d.\n", device->security_bit_state);
     } else {
         // Security bit not present or not testable.
         device->security_bit_state = ATMEL_SECURE_OFF;
     }
 }
 
-static void security_message( dfu_device_t *device ) {
-    if( device->security_bit_state > ATMEL_SECURE_OFF ) {
-        fprintf( stderr, "The security bit %s set.\n"
-                         "Erase the device to clear temporarily.\n",
-                         (ATMEL_SECURE_ON == device->security_bit_state) ? "is" : "may be" );
+static void
+security_message (dfu_device_t *device) {
+    if (device->security_bit_state > ATMEL_SECURE_OFF) {
+        fprintf (stderr,
+                 "The security bit %s set.\n"
+                 "Erase the device to clear temporarily.\n",
+                 (ATMEL_SECURE_ON == device->security_bit_state) ? "is" : "may be");
     }
 }
 
-static int32_t execute_erase( dfu_device_t *device,
-                              struct programmer_arguments *args ) {
+static int32_t
+execute_erase (dfu_device_t *device, struct programmer_arguments *args) {
     int32_t result = SUCCESS;
 
-    if( !(GRP_STM32 & args->device_type) && !args->com_erase_data.force ) {
-        if( 0 == atmel_blank_check( device, args->flash_address_bottom,
-                                             args->flash_address_top,
-                                             args->quiet ) ) {
-            if ( !args->quiet ) {
-                fprintf( stderr, "Chip already blank, to force erase use --force.\n");
-            }
+    if (!(GRP_STM32 & args->device_type) && !args->com_erase_data.force) {
+        if (0 == atmel_blank_check (device, args->flash_address_bottom, args->flash_address_top, args->quiet)) {
+            if (!args->quiet) { fprintf (stderr, "Chip already blank, to force erase use --force.\n"); }
             return SUCCESS;
         }
     }
 
-    DEBUG( "erase 0x%X bytes.\n",
-           (args->flash_address_top - args->flash_address_bottom) );
+    DEBUG ("erase 0x%X bytes.\n", (args->flash_address_top - args->flash_address_bottom));
 
-    if( GRP_STM32 & args->device_type ) {
-        result = stm32_erase_flash( device, args->quiet );
+    if (GRP_STM32 & args->device_type) {
+        result = stm32_erase_flash (device, args->quiet);
     } else {
-        result = atmel_erase_flash( device, ATMEL_ERASE_ALL, args->quiet );
+        result = atmel_erase_flash (device, ATMEL_ERASE_ALL, args->quiet);
     }
 
-    if( 0 != result ) {
-        return result;
-    }
+    if (0 != result) { return result; }
 
-    if( !(GRP_STM32 & args->device_type) &&
-            !args->com_erase_data.suppress_validation ) {
-        result = atmel_blank_check( device, args->flash_address_bottom,
-                                            args->flash_address_top,
-                                            args->quiet );
+    if (!(GRP_STM32 & args->device_type) && !args->com_erase_data.suppress_validation) {
+        result = atmel_blank_check (device, args->flash_address_bottom, args->flash_address_top, args->quiet);
     }
     return result;
 }
 
-static int32_t execute_setsecure( dfu_device_t *device,
-                                  struct programmer_arguments *args ) {
+static int32_t
+execute_setsecure (dfu_device_t *device, struct programmer_arguments *args) {
     int32_t result;
 
-    if( ADC_AVR32 != args->device_type ) {
-        DEBUG( "target doesn't support security bit set.\n" );
-        fprintf( stderr,  "Operation not supported on %s\n",
-                args->device_type_string );
+    if (ADC_AVR32 != args->device_type) {
+        DEBUG ("target doesn't support security bit set.\n");
+        fprintf (stderr, "Operation not supported on %s\n", args->device_type_string);
         return ARGUMENT_ERROR;
     }
 
-    result = atmel_secure( device );
+    result = atmel_secure (device);
 
-    if( result < 0 ) {
-        DEBUG( "Error while setting security bit. (%d)\n", result );
-        fprintf( stderr, "Error setting security bit.\n" );
+    if (result < 0) {
+        DEBUG ("Error while setting security bit. (%d)\n", result);
+        fprintf (stderr, "Error setting security bit.\n");
         return UNSPECIFIED_ERROR;
     }
 
@@ -132,62 +120,56 @@ static int32_t execute_setsecure( dfu_device_t *device,
 // otherwise, the section will end up '\0' unless a page erase is used.. so may
 // need to keep this part of the flash command, but specify that serialize data
 // 'wins' over data from the hex file
-static int32_t serialize_memory_image( intel_buffer_out_t *bout,
-                                     struct programmer_arguments *args ) {
+static int32_t
+serialize_memory_image (intel_buffer_out_t *bout, struct programmer_arguments *args) {
     uint32_t target_offset = 0;
-    if( args->command == com_user )
+    if (args->command == com_user)
         target_offset = ATMEL_USER_PAGE_OFFSET;
-    else if( args->device_type & GRP_STM32 )
+    else if (args->device_type & GRP_STM32)
         target_offset = STM32_FLASH_OFFSET;
 
-    if ( NULL != args->com_flash_data.serial_data ) {
+    if (NULL != args->com_flash_data.serial_data) {
         int16_t *serial_data = args->com_flash_data.serial_data;
         uint32_t length = args->com_flash_data.serial_length;
         uint32_t offset = args->com_flash_data.serial_offset;
         uint32_t i;
 
-        for( i=0; i < length; ++i ) {
-            if ( 0 != intel_process_data(bout, serial_data[i],
-                        target_offset, offset + i) ) {
-                return BUFFER_INIT_ERROR;
-            }
+        for (i = 0; i < length; ++i) {
+            if (0 != intel_process_data (bout, serial_data[i], target_offset, offset + i)) { return BUFFER_INIT_ERROR; }
         }
     }
     return SUCCESS;
 }
 
-static int32_t execute_validate( dfu_device_t *device,
-                                 intel_buffer_out_t *bout,
-                                 uint8_t mem_segment,
-                                 const bool quiet,
-                                 const bool ignore_outside) {
+static int32_t
+execute_validate (dfu_device_t *device, intel_buffer_out_t *bout, uint8_t mem_segment, const bool quiet,
+                  const bool ignore_outside) {
     int32_t retval = UNSPECIFIED_ERROR;
-    int32_t result;             // result of fcn calls
-    intel_buffer_in_t buin;     // buffer in for storing read mem
+    int32_t result;         // result of fcn calls
+    intel_buffer_in_t buin; // buffer in for storing read mem
 
-    if( 0 != intel_init_buffer_in(&buin, bout->info.total_size,
-                                            bout->info.page_size ) ) {
-        DEBUG("ERROR initializing a buffer.\n");
+    if (0 != intel_init_buffer_in (&buin, bout->info.total_size, bout->info.page_size)) {
+        DEBUG ("ERROR initializing a buffer.\n");
         retval = BUFFER_INIT_ERROR;
         goto error;
     }
     buin.info.data_start = bout->info.valid_start;
     buin.info.data_end = bout->info.valid_end;
 
-    if( device->type & GRP_STM32 ) {
-        result = stm32_read_flash( device, &buin, mem_segment, quiet );
+    if (device->type & GRP_STM32) {
+        result = stm32_read_flash (device, &buin, mem_segment, quiet);
     } else {
-        result = atmel_read_flash( device, &buin, mem_segment, quiet );
+        result = atmel_read_flash (device, &buin, mem_segment, quiet);
     }
 
-    if( 0 != result ) {
-        DEBUG("ERROR: could not read memory, err %d.\n", result);
+    if (0 != result) {
+        DEBUG ("ERROR: could not read memory, err %d.\n", result);
         retval = FLASH_READ_ERROR;
         goto error;
     }
 
-    if( 0 != (result = intel_validate_buffer( &buin, bout, quiet )) ) {
-        if( result < 0 ) {
+    if (0 != (result = intel_validate_buffer (&buin, bout, quiet))) {
+        if (result < 0) {
             retval = VALIDATION_ERROR_IN_REGION;
         } else {
             if (ignore_outside) {
@@ -202,152 +184,136 @@ static int32_t execute_validate( dfu_device_t *device,
     retval = SUCCESS;
 
 error:
-    if( !quiet && SUCCESS != retval ) fprintf( stderr, "FAIL\n" );
+    if (!quiet && SUCCESS != retval) fprintf (stderr, "FAIL\n");
 
-    if( NULL != buin.data ) {
-        free( buin.data );
+    if (NULL != buin.data) {
+        free (buin.data);
         buin.data = NULL;
     }
 
     return retval;
 }
 
-static void print_flash_usage( intel_buffer_info_t *info ) {
-    fprintf( stderr,
-            "0x%X bytes written into 0x%X bytes memory (%.02f%%).\n",
-            info->data_end - info->data_start + 1,
-            info->valid_end - info->valid_start + 1,
-            ((float) (100 * (info->data_end - info->data_start + 1)) /
-                (float) (info->valid_end - info->valid_start + 1)) ) ;
+static void
+print_flash_usage (intel_buffer_info_t *info) {
+    fprintf (
+        stderr, "0x%X bytes written into 0x%X bytes memory (%.02f%%).\n", info->data_end - info->data_start + 1,
+        info->valid_end - info->valid_start + 1,
+        ((float)(100 * (info->data_end - info->data_start + 1)) / (float)(info->valid_end - info->valid_start + 1)));
 }
 
-static int32_t execute_flash( dfu_device_t *device,
-                                struct programmer_arguments *args ) {
-    int32_t  retval = UNSPECIFIED_ERROR;
-    int32_t  result;
-    uint32_t  i;
+static int32_t
+execute_flash (dfu_device_t *device, struct programmer_arguments *args) {
+    int32_t retval = UNSPECIFIED_ERROR;
+    int32_t result;
+    uint32_t i;
     intel_buffer_out_t bout;
-    size_t   memory_size;
-    size_t   page_size;
+    size_t memory_size;
+    size_t page_size;
     enum atmel_memory_unit_enum mem_type = args->com_flash_data.segment;
     uint32_t target_offset = 0;
 
     /* assign the correct memory size */
-    switch ( mem_type ) {
-        case mem_flash:
-            if( args->device_type & GRP_STM32 ) {
-                target_offset = STM32_FLASH_OFFSET;
-            }
-            memory_size = args->memory_address_top + 1;
-            page_size = args->flash_page_size;
-            break;
-        case mem_eeprom:
-            if( 0 == args->eeprom_memory_size ) {
-                fprintf( stderr, "This device has no eeprom.\n" );
-                return ARGUMENT_ERROR;
-            }
-            memory_size = args->eeprom_memory_size;
-            page_size = args->eeprom_page_size;
-            break;
-        case mem_user:
-            memory_size = args->flash_page_size;
-            page_size = args->flash_page_size;
-            mem_type = mem_user;
-            target_offset = ATMEL_USER_PAGE_OFFSET;
-            if( args->device_type != ADC_AVR32 ){
-                fprintf(stderr, "Flash User only implemented for ADC_AVR32 devices.\n");
-                retval = ARGUMENT_ERROR;
-                goto error;
-            }
-            break;
-        default:
-            DEBUG("Unknown memory type %d\n", mem_type);
+    switch (mem_type) {
+    case mem_flash:
+        if (args->device_type & GRP_STM32) { target_offset = STM32_FLASH_OFFSET; }
+        memory_size = args->memory_address_top + 1;
+        page_size = args->flash_page_size;
+        break;
+    case mem_eeprom:
+        if (0 == args->eeprom_memory_size) {
+            fprintf (stderr, "This device has no eeprom.\n");
             return ARGUMENT_ERROR;
+        }
+        memory_size = args->eeprom_memory_size;
+        page_size = args->eeprom_page_size;
+        break;
+    case mem_user:
+        memory_size = args->flash_page_size;
+        page_size = args->flash_page_size;
+        mem_type = mem_user;
+        target_offset = ATMEL_USER_PAGE_OFFSET;
+        if (args->device_type != ADC_AVR32) {
+            fprintf (stderr, "Flash User only implemented for ADC_AVR32 devices.\n");
+            retval = ARGUMENT_ERROR;
+            goto error;
+        }
+        break;
+    default: DEBUG ("Unknown memory type %d\n", mem_type); return ARGUMENT_ERROR;
     }
 
     // ----------------- CONVERT HEX FILE TO BINARY -------------------------
-    if( 0 != intel_init_buffer_out(&bout, memory_size, page_size) ) {
-        DEBUG("ERROR initializing a buffer.\n");
+    if (0 != intel_init_buffer_out (&bout, memory_size, page_size)) {
+        DEBUG ("ERROR initializing a buffer.\n");
         retval = BUFFER_INIT_ERROR;
         goto error;
     }
 
-    result = intel_hex_to_buffer( args->com_flash_data.file, &bout,
-            target_offset, args->quiet );
+    result = intel_hex_to_buffer (args->com_flash_data.file, &bout, target_offset, args->quiet);
 
-    if ( result < 0 ) {
-        DEBUG( "Something went wrong with creating the memory image.\n" );
+    if (result < 0) {
+        DEBUG ("Something went wrong with creating the memory image.\n");
         retval = BUFFER_INIT_ERROR;
         goto error;
-    } else if ( result > 0 ) {
-        DEBUG( "WARNING: File contains 0x%X bytes outside target memory.\n",
-                result );
-        if( mem_type == mem_flash ) {
-            DEBUG( "There may be data in the user page (offset %#X).\n",
-                    ATMEL_USER_PAGE_OFFSET );
-            DEBUG( "Inspect the hex file or try flash-user.\n" );
+    } else if (result > 0) {
+        DEBUG ("WARNING: File contains 0x%X bytes outside target memory.\n", result);
+        if (mem_type == mem_flash) {
+            DEBUG ("There may be data in the user page (offset %#X).\n", ATMEL_USER_PAGE_OFFSET);
+            DEBUG ("Inspect the hex file or try flash-user.\n");
         }
-        if( !args->quiet ) {
-            fprintf( stderr,
-                    "WARNING: 0x%X bytes are outside target memory,\n", result );
-            fprintf( stderr, " and will not be written.\n" );
+        if (!args->quiet) {
+            fprintf (stderr, "WARNING: 0x%X bytes are outside target memory,\n", result);
+            fprintf (stderr, " and will not be written.\n");
         }
     }
-// TODO : consider accepting a string to flash to the user page as well as a hex
-// file.. this would be easier than using serialize and could return the address
-// location of the start of the string (to be used in the program file)
+    // TODO : consider accepting a string to flash to the user page as well as a hex
+    // file.. this would be easier than using serialize and could return the address
+    // location of the start of the string (to be used in the program file)
 
-    if (0 != serialize_memory_image( &bout, args )) {
+    if (0 != serialize_memory_image (&bout, args)) {
         retval = BUFFER_INIT_ERROR;
         goto error;
     }
 
-    if( mem_type == mem_flash ) {
+    if (mem_type == mem_flash) {
         bout.info.valid_start = args->flash_address_bottom;
         bout.info.valid_end = args->flash_address_top;
 
         // check that there isn't anything overlapping the bootloader
-        for( i = args->bootloader_bottom; i <= args->bootloader_top; i++) {
-            if( bout.data[i] <= UINT8_MAX ) {
-                if( true == args->suppressBootloader ) {
-                    //If we're ignoring the bootloader, don't write to it
+        for (i = args->bootloader_bottom; i <= args->bootloader_top; i++) {
+            if (bout.data[i] <= UINT8_MAX) {
+                if (true == args->suppressBootloader) {
+                    // If we're ignoring the bootloader, don't write to it
                     bout.data[i] = UINT16_MAX;
                 } else {
-                    fprintf( stderr, "Bootloader and code overlap.\n" );
-                    fprintf( stderr, "Use --suppress-bootloader-mem to ignore\n" );
+                    fprintf (stderr, "Bootloader and code overlap.\n");
+                    fprintf (stderr, "Use --suppress-bootloader-mem to ignore\n");
                     retval = BUFFER_INIT_ERROR;
                     goto error;
                 }
             }
         }
-    } else if ( mem_type == mem_user ) {
+    } else if (mem_type == mem_user) {
         // check here about overwriting?
 
-        if ( bout.info.data_start == UINT32_MAX ) {
-            fprintf( stderr,
-                    "ERROR: No data to write into the user page.\n" );
+        if (bout.info.data_start == UINT32_MAX) {
+            fprintf (stderr, "ERROR: No data to write into the user page.\n");
             retval = BUFFER_INIT_ERROR;
             goto error;
         } else {
-            DEBUG("Hex file contains %u bytes to write.\n",
-                    bout.info.data_end - bout.info.data_start + 1 );
+            DEBUG ("Hex file contains %u bytes to write.\n", bout.info.data_end - bout.info.data_start + 1);
         }
 
-        if ( !(args->com_flash_data.force) ) {
+        if (!(args->com_flash_data.force)) {
             /* depending on the version of the bootloader, there could be
-            * configuration values in the last word or last two words of the
-            * user page.  If these are overwritten the device may not start.
-            * A warning should be issued before these values can be changed. */
-            fprintf( stderr,
-                    "ERROR: --force flag is required to write user page.\n" );
-            fprintf( stderr,
-                    " Last word(s) in user page contain configuration data.\n");
-            fprintf( stderr,
-                    " The user page is erased whenever any data is written.\n");
-            fprintf( stderr,
-                    " Without valid config. device always resets in bootloader.\n");
-            fprintf( stderr,
-                    " Use dump-user to obtain valid configuration words.\n");
+             * configuration values in the last word or last two words of the
+             * user page.  If these are overwritten the device may not start.
+             * A warning should be issued before these values can be changed. */
+            fprintf (stderr, "ERROR: --force flag is required to write user page.\n");
+            fprintf (stderr, " Last word(s) in user page contain configuration data.\n");
+            fprintf (stderr, " The user page is erased whenever any data is written.\n");
+            fprintf (stderr, " Without valid config. device always resets in bootloader.\n");
+            fprintf (stderr, " Use dump-user to obtain valid configuration words.\n");
             retval = ARGUMENT_ERROR;
             goto error;
             // TODO : implement so this error only appears when data overlaps the
@@ -356,13 +322,11 @@ static int32_t execute_flash( dfu_device_t *device,
             // checking the bootloader version to make sure the right number of
             // words are blocked / written.
             //  ----------- the below for loop is not currently in use -----------
-            for ( i = bout.info.total_size - 8; i < bout.info.total_size; i++ ) {
-                if ( -1 != bout.data[i] ) {
-                    fprintf( stderr,
-                            "ERROR: data overlap with bootloader configuration word(s).\n" );
-                    DEBUG( "At position %d, value is %d.\n", i, bout.data[i] );
-                    fprintf( stderr,
-                            "ERROR: use the --force-config flag to write the data.\n" );
+            for (i = bout.info.total_size - 8; i < bout.info.total_size; i++) {
+                if (-1 != bout.data[i]) {
+                    fprintf (stderr, "ERROR: data overlap with bootloader configuration word(s).\n");
+                    DEBUG ("At position %d, value is %d.\n", i, bout.data[i]);
+                    fprintf (stderr, "ERROR: use the --force-config flag to write the data.\n");
                     retval = ARGUMENT_ERROR;
                     goto error;
                 }
@@ -371,140 +335,135 @@ static int32_t execute_flash( dfu_device_t *device,
     }
 
     // ------------------ INITIAL VALIDATE (if required) -------------------
-    if ( 1 == args->com_flash_data.validate_first ) {
-        if( 0 == ( retval = execute_validate(device, &bout, mem_type, args->quiet,
-                                             args->com_flash_data.ignore_outside)) ) {
+    if (1 == args->com_flash_data.validate_first) {
+        if (0
+            == (retval
+                = execute_validate (device, &bout, mem_type, args->quiet, args->com_flash_data.ignore_outside))) {
             goto success;
         }
         // Else, continue to flash
     }
 
     // ------------------ WRITE PROGRAM DATA -------------------------------
-    if( mem_type == mem_user ) {
-        result = atmel_user( device, &bout );
+    if (mem_type == mem_user) {
+        result = atmel_user (device, &bout);
     } else {
-        if( args->device_type & GRP_STM32 ) {
-            result = stm32_write_flash( device, &bout,
-                    mem_type == mem_eeprom ? true : false,
-                    args->com_flash_data.force, args->quiet );
+        if (args->device_type & GRP_STM32) {
+            result = stm32_write_flash (device, &bout, mem_type == mem_eeprom ? true : false,
+                                        args->com_flash_data.force, args->quiet);
         } else {
-            result = atmel_flash(device, &bout,
-                    mem_type == mem_eeprom ? true : false,
-                    args->com_flash_data.force, args->quiet);
+            result = atmel_flash (device, &bout, mem_type == mem_eeprom ? true : false, args->com_flash_data.force,
+                                  args->quiet);
         }
     }
-    if( 0 != result ) {
-        DEBUG( "Error writing %s data. (err %d)\n", "memory", result );
+    if (0 != result) {
+        DEBUG ("Error writing %s data. (err %d)\n", "memory", result);
         retval = FLASH_WRITE_ERROR;
         goto error;
     }
 
     // ------------------  VALIDATE PROGRAM ------------------------------
-    if( 0 == args->com_flash_data.suppress_validation ) {
-        if( 0 != ( retval = execute_validate(device, &bout, mem_type, args->quiet,
-                                             args->com_flash_data.ignore_outside)) ) {
-            fprintf( stderr, "Memory did not validate. Did you erase?\n" );
+    if (0 == args->com_flash_data.suppress_validation) {
+        if (0
+            != (retval
+                = execute_validate (device, &bout, mem_type, args->quiet, args->com_flash_data.ignore_outside))) {
+            fprintf (stderr, "Memory did not validate. Did you erase?\n");
             goto error;
-        } else if ( 0 == args->quiet ) {
-            print_flash_usage( &bout.info );
+        } else if (0 == args->quiet) {
+            print_flash_usage (&bout.info);
         }
-    } else if( 0 == args->quiet ) {
-        print_flash_usage( &bout.info );
+    } else if (0 == args->quiet) {
+        print_flash_usage (&bout.info);
     }
 
 success:
     retval = SUCCESS;
 
 error:
-    if( NULL != bout.data ) {
-        free( bout.data );
+    if (NULL != bout.data) {
+        free (bout.data);
         bout.data = NULL;
     }
 
     return retval;
 }
 
-static int32_t execute_getfuse( dfu_device_t *device,
-                            struct programmer_arguments *args ) {
+static int32_t
+execute_getfuse (dfu_device_t *device, struct programmer_arguments *args) {
     atmel_avr32_fuses_t info;
     char *message = NULL;
     int32_t value = 0;
     int32_t status;
 
     /* only ADC_AVR32 seems to support fuse operation */
-    if( !(ADC_AVR32 & args->device_type) ) {
-        DEBUG( "target doesn't support fuse set operation.\n" );
-        fprintf( stderr, "target doesn't support fuse set operation.\n" );
+    if (!(ADC_AVR32 & args->device_type)) {
+        DEBUG ("target doesn't support fuse set operation.\n");
+        fprintf (stderr, "target doesn't support fuse set operation.\n");
         return ARGUMENT_ERROR;
     }
 
     /* Check AVR32 security bit in order to provide a better error message. */
-    security_check( device );
+    security_check (device);
 
-    if( args->device_type & GRP_STM32 ) {
-        fprintf( stderr, "Operation not supported on %s.\n",
-                args->device_type_string );
+    if (args->device_type & GRP_STM32) {
+        fprintf (stderr, "Operation not supported on %s.\n", args->device_type_string);
         return ARGUMENT_ERROR;
     } else {
-        status = atmel_read_fuses( device, &info );
+        status = atmel_read_fuses (device, &info);
     }
 
-    if( 0 != status ) {
-        DEBUG( "Error reading %s config information.\n",
-               args->device_type_string );
-        fprintf( stderr, "Error reading %s config information.\n",
-                         args->device_type_string );
-        security_message( device );
+    if (0 != status) {
+        DEBUG ("Error reading %s config information.\n", args->device_type_string);
+        fprintf (stderr, "Error reading %s config information.\n", args->device_type_string);
+        security_message (device);
         return status;
     }
 
-    switch( args->com_getfuse_data.name ) {
-        case get_lock:
-            value = info.lock;
-            message = "Locked regions";
-            break;
-        case get_epfl:
-            value = info.epfl;
-            message = "External Privileged Fetch Lock";
-            break;
-        case get_bootprot:
-            value = info.bootprot;
-            message = "Bootloader protected area";
-            break;
-        case get_bodlevel:
-            value = info.bodlevel;
-            message = "Brown-out detector trigger level";
-            break;
-        case get_bodhyst:
-            value = info.bodhyst;
-            message = "BOD Hysteresis enable";
-            break;
-        case get_boden:
-            value = info.boden;
-            message = "BOD Enable";
-            break;
-        case get_isp_bod_en:
-            value = info.isp_bod_en;
-            message = "ISP BOD enable";
-            break;
-        case get_isp_io_cond_en:
-            value = info.isp_io_cond_en;
-            message = "ISP IO condition enable";
-            break;
-        case get_isp_force:
-            value = info.isp_force;
-            message = "ISP Force";
-            break;
+    switch (args->com_getfuse_data.name) {
+    case get_lock:
+        value = info.lock;
+        message = "Locked regions";
+        break;
+    case get_epfl:
+        value = info.epfl;
+        message = "External Privileged Fetch Lock";
+        break;
+    case get_bootprot:
+        value = info.bootprot;
+        message = "Bootloader protected area";
+        break;
+    case get_bodlevel:
+        value = info.bodlevel;
+        message = "Brown-out detector trigger level";
+        break;
+    case get_bodhyst:
+        value = info.bodhyst;
+        message = "BOD Hysteresis enable";
+        break;
+    case get_boden:
+        value = info.boden;
+        message = "BOD Enable";
+        break;
+    case get_isp_bod_en:
+        value = info.isp_bod_en;
+        message = "ISP BOD enable";
+        break;
+    case get_isp_io_cond_en:
+        value = info.isp_io_cond_en;
+        message = "ISP IO condition enable";
+        break;
+    case get_isp_force:
+        value = info.isp_force;
+        message = "ISP Force";
+        break;
     }
-    fprintf( stdout, "%s%s0x%02x (%d)\n",
-             ((0 == args->quiet) ? message : ""),
-             ((0 == args->quiet) ? ": " : ""),
-             value, value );
+    fprintf (stdout, "%s%s0x%02x (%d)\n", ((0 == args->quiet) ? message : ""), ((0 == args->quiet) ? ": " : ""), value,
+             value);
     return 0;
 }
 
-static int32_t execute_get( dfu_device_t *device,
-                            struct programmer_arguments *args ) {
+static int32_t
+execute_get (dfu_device_t *device, struct programmer_arguments *args) {
     atmel_device_info_t info;
     char *message = NULL;
     int16_t value = 0;
@@ -512,352 +471,311 @@ static int32_t execute_get( dfu_device_t *device,
     int32_t controller_error = 0;
 
     /* Check AVR32 security bit in order to provide a better error message. */
-    security_check( device );
+    security_check (device);
 
-    if( args->device_type & GRP_STM32 ) {
-        fprintf( stderr, "Operation not supported on %s.\n",
-                args->device_type_string );
+    if (args->device_type & GRP_STM32) {
+        fprintf (stderr, "Operation not supported on %s.\n", args->device_type_string);
         return -1;
     } else {
-        status = atmel_read_config( device, &info );
+        status = atmel_read_config (device, &info);
     }
 
-    if( 0 != status ) {
-        DEBUG( "Error reading %s config information.\n",
-               args->device_type_string );
-        fprintf( stderr, "Error reading %s config information.\n",
-                         args->device_type_string );
-        security_message( device );
+    if (0 != status) {
+        DEBUG ("Error reading %s config information.\n", args->device_type_string);
+        fprintf (stderr, "Error reading %s config information.\n", args->device_type_string);
+        security_message (device);
         return status;
     }
 
-    switch( args->com_get_data.name ) {
-        case get_bootloader:
-            value = info.bootloaderVersion;
-            message = "Bootloader Version";
-            break;
-        case get_ID1:
-            value = info.bootID1;
-            message = "Device boot ID 1";
-            break;
-        case get_ID2:
-            value = info.bootID2;
-            message = "Device boot ID 2";
-            break;
-        case get_BSB:
-            value = info.bsb;
-            message = "Boot Status Byte";
-            if( ADC_8051 != args->device_type ) {
-                controller_error = 1;
-            }
-            break;
-        case get_SBV:
-            value = info.sbv;
-            message = "Software Boot Vector";
-            if( ADC_8051 != args->device_type ) {
-                controller_error = 1;
-            }
-            break;
-        case get_SSB:
-            value = info.ssb;
-            message = "Software Security Byte";
-            if( ADC_8051 != args->device_type ) {
-                controller_error = 1;
-            }
-            break;
-        case get_EB:
-            value = info.eb;
-            message = "Extra Byte";
-            if( ADC_8051 != args->device_type ) {
-                controller_error = 1;
-            }
-            break;
-        case get_manufacturer:
-            value = info.manufacturerCode;
-            message = "Manufacturer Code";
-            break;
-        case get_family:
-            value = info.familyCode;
-            message = "Family Code";
-            break;
-        case get_product_name:
-            value = info.productName;
-            message = "Product Name";
-            break;
-        case get_product_rev:
-            value = info.productRevision;
-            message = "Product Revision";
-            break;
-        case get_HSB:
-            value = info.hsb;
-            message = "Hardware Security Byte";
-            if( ADC_8051 != args->device_type ) {
-                controller_error = 1;
-            }
-            break;
+    switch (args->com_get_data.name) {
+    case get_bootloader:
+        value = info.bootloaderVersion;
+        message = "Bootloader Version";
+        break;
+    case get_ID1:
+        value = info.bootID1;
+        message = "Device boot ID 1";
+        break;
+    case get_ID2:
+        value = info.bootID2;
+        message = "Device boot ID 2";
+        break;
+    case get_BSB:
+        value = info.bsb;
+        message = "Boot Status Byte";
+        if (ADC_8051 != args->device_type) { controller_error = 1; }
+        break;
+    case get_SBV:
+        value = info.sbv;
+        message = "Software Boot Vector";
+        if (ADC_8051 != args->device_type) { controller_error = 1; }
+        break;
+    case get_SSB:
+        value = info.ssb;
+        message = "Software Security Byte";
+        if (ADC_8051 != args->device_type) { controller_error = 1; }
+        break;
+    case get_EB:
+        value = info.eb;
+        message = "Extra Byte";
+        if (ADC_8051 != args->device_type) { controller_error = 1; }
+        break;
+    case get_manufacturer:
+        value = info.manufacturerCode;
+        message = "Manufacturer Code";
+        break;
+    case get_family:
+        value = info.familyCode;
+        message = "Family Code";
+        break;
+    case get_product_name:
+        value = info.productName;
+        message = "Product Name";
+        break;
+    case get_product_rev:
+        value = info.productRevision;
+        message = "Product Revision";
+        break;
+    case get_HSB:
+        value = info.hsb;
+        message = "Hardware Security Byte";
+        if (ADC_8051 != args->device_type) { controller_error = 1; }
+        break;
     }
 
-    if( 0 != controller_error ) {
-        DEBUG( "%s requires 8051 based controller\n", message );
-        fprintf( stderr, "%s requires 8051 based controller\n",
-                         message );
+    if (0 != controller_error) {
+        DEBUG ("%s requires 8051 based controller\n", message);
+        fprintf (stderr, "%s requires 8051 based controller\n", message);
         return -1;
     }
 
-    if( value < 0 ) {
-        fprintf( stderr, "The requested device info is unavailable.\n" );
+    if (value < 0) {
+        fprintf (stderr, "The requested device info is unavailable.\n");
         return -2;
     }
 
-    fprintf( stdout, "%s%s0x%02x (%d)\n",
-             ((0 == args->quiet) ? message : ""),
-             ((0 == args->quiet) ? ": " : ""),
-             value, value );
+    fprintf (stdout, "%s%s0x%02x (%d)\n", ((0 == args->quiet) ? message : ""), ((0 == args->quiet) ? ": " : ""), value,
+             value);
     return 0;
 }
 
-static int32_t execute_dump( dfu_device_t *device,
-                             struct programmer_arguments *args ) {
+static int32_t
+execute_dump (dfu_device_t *device, struct programmer_arguments *args) {
     int32_t i = 0;
     int32_t retval = UNSPECIFIED_ERROR;
-    int32_t result;             // result of fcn calls
-    intel_buffer_in_t buin;     // buffer in for storing read mem
+    int32_t result;         // result of fcn calls
+    intel_buffer_in_t buin; // buffer in for storing read mem
     enum atmel_memory_unit_enum mem_segment = args->com_read_data.segment;
     size_t mem_size = 0;
     size_t page_size = 0;
     uint32_t target_offset = 0; // address offset on the target device
-        // NOTE: target_offset may not be set appropriately for device
-        // classes other than ADC_AVR32
+                                // NOTE: target_offset may not be set appropriately for device
+                                // classes other than ADC_AVR32
 
-    switch( mem_segment ) {
-        case mem_flash:
-            mem_size = args->memory_address_top + 1;
-            page_size = args->flash_page_size;
-            if( ADC_AVR32 == args->device_type ) {
-                target_offset = 0x80000000;
-            } else if( GRP_STM32 & args->device_type ) {
-                target_offset = STM32_FLASH_OFFSET;
-            }
-            break;
-        case mem_eeprom:
-            mem_size = args->eeprom_memory_size;
-            page_size = args->eeprom_page_size;
-            break;
-        case mem_user:
-            mem_size = args->flash_page_size;
-            page_size = args->flash_page_size;
-            target_offset = 0x80800000;
-            break;
-        default:
-            fprintf( stderr, "Dump not currently supported for this memory.\n" );
-            retval = ARGUMENT_ERROR;
-            goto error;
+    switch (mem_segment) {
+    case mem_flash:
+        mem_size = args->memory_address_top + 1;
+        page_size = args->flash_page_size;
+        if (ADC_AVR32 == args->device_type) {
+            target_offset = 0x80000000;
+        } else if (GRP_STM32 & args->device_type) {
+            target_offset = STM32_FLASH_OFFSET;
+        }
+        break;
+    case mem_eeprom:
+        mem_size = args->eeprom_memory_size;
+        page_size = args->eeprom_page_size;
+        break;
+    case mem_user:
+        mem_size = args->flash_page_size;
+        page_size = args->flash_page_size;
+        target_offset = 0x80800000;
+        break;
+    default:
+        fprintf (stderr, "Dump not currently supported for this memory.\n");
+        retval = ARGUMENT_ERROR;
+        goto error;
     }
 
-    if( 0 != intel_init_buffer_in(&buin, mem_size, page_size) ) {
-        DEBUG("ERROR initializing a buffer.\n");
+    if (0 != intel_init_buffer_in (&buin, mem_size, page_size)) {
+        DEBUG ("ERROR initializing a buffer.\n");
         retval = BUFFER_INIT_ERROR;
         goto error;
     }
 
-    if( mem_segment == mem_flash ) {
+    if (mem_segment == mem_flash) {
         buin.info.data_start = args->flash_address_bottom;
         buin.info.data_end = args->flash_address_top;
     }
 
-    if( args->device_type & GRP_STM32 ) {
-        result = stm32_read_flash(device, &buin, mem_segment, args->quiet);
+    if (args->device_type & GRP_STM32) {
+        result = stm32_read_flash (device, &buin, mem_segment, args->quiet);
     } else {
         /* Check AVR32 security bit in order to provide a better error message */
-        security_check( device );   // avr32 has no eeprom, but OK
-        result = atmel_read_flash(device, &buin, mem_segment, args->quiet);
+        security_check (device); // avr32 has no eeprom, but OK
+        result = atmel_read_flash (device, &buin, mem_segment, args->quiet);
     }
 
-    if( 0 != result ) {
-        DEBUG("ERROR: could not read memory, err %d.\n", result);
-        security_message( device );
+    if (0 != result) {
+        DEBUG ("ERROR: could not read memory, err %d.\n", result);
+        security_message (device);
         retval = FLASH_READ_ERROR;
         goto error;
     }
 
     // determine first & last page with non-blank data
-    if( args->com_read_data.force ) {
+    if (args->com_read_data.force) {
         buin.info.data_start = 0;
     } else {
         // find first page with data
-        for( i = buin.info.data_start; i < buin.info.data_end; i++ ) {
-            if( buin.data[i] != 0xFF ) break;
-            if( i / buin.info.page_size >
-                    buin.info.data_start / buin.info.page_size ) {
+        for (i = buin.info.data_start; i < buin.info.data_end; i++) {
+            if (buin.data[i] != 0xFF) break;
+            if (i / buin.info.page_size > buin.info.data_start / buin.info.page_size) {
                 // i has just jumped to a different page than buin.data_start
                 buin.info.data_start = i;
             }
         }
-        if( i == buin.info.data_end ) {
-            if( !args->quiet )
-                fprintf( stderr,
-                        "Memory is blank, returning a single blank page.\n"
-                        "Use --force to return the entire memory regardless.\n");
+        if (i == buin.info.data_end) {
+            if (!args->quiet)
+                fprintf (stderr, "Memory is blank, returning a single blank page.\n"
+                                 "Use --force to return the entire memory regardless.\n");
             buin.info.data_start = 0;
             buin.info.data_end = buin.info.page_size - 1;
-        } else {        // find last page with data
-            for( i = buin.info.data_end; i > buin.info.data_start; i-- ) {
-                if( buin.data[i] !=0xFF ) break;
-                if( i / buin.info.page_size <
-                        buin.info.data_end / buin.info.page_size ) {
-                    buin.info.data_end = i;
-                }
+        } else { // find last page with data
+            for (i = buin.info.data_end; i > buin.info.data_start; i--) {
+                if (buin.data[i] != 0xFF) break;
+                if (i / buin.info.page_size < buin.info.data_end / buin.info.page_size) { buin.info.data_end = i; }
             }
         }
     }
 
-    if( args->com_read_data.bin ) {
-        if( !args->quiet )
-            fprintf( stderr, "Dumping 0x%X bytes from address offset 0x%X.\n",
-                    buin.info.data_end + 1, target_offset );
-        for( i = 0; i <= buin.info.data_end; i++ ) {
-            fprintf( stdout, "%c", buin.data[i] );
-        }
+    if (args->com_read_data.bin) {
+        if (!args->quiet)
+            fprintf (stderr, "Dumping 0x%X bytes from address offset 0x%X.\n", buin.info.data_end + 1, target_offset);
+        for (i = 0; i <= buin.info.data_end; i++) { fprintf (stdout, "%c", buin.data[i]); }
     } else {
-        if( !args->quiet )
-            fprintf( stderr, "Dumping 0x%X bytes from address offset 0x%X.\n",
-                    buin.info.data_end - buin.info.data_start + 1,
-                    target_offset + buin.info.data_start );
-        intel_hex_from_buffer( &buin,
-                args->com_read_data.force, target_offset );
+        if (!args->quiet)
+            fprintf (stderr, "Dumping 0x%X bytes from address offset 0x%X.\n",
+                     buin.info.data_end - buin.info.data_start + 1, target_offset + buin.info.data_start);
+        intel_hex_from_buffer (&buin, args->com_read_data.force, target_offset);
     }
 
-    fflush( stdout );
+    fflush (stdout);
 
     retval = SUCCESS;
 
 error:
-    if( NULL != buin.data ) {
-        free( buin.data );
+    if (NULL != buin.data) {
+        free (buin.data);
         buin.data = NULL;
     }
 
     return retval;
 }
 
-static int32_t execute_setfuse( dfu_device_t *device,
-                                  struct programmer_arguments *args ) {
+static int32_t
+execute_setfuse (dfu_device_t *device, struct programmer_arguments *args) {
     int32_t value = args->com_setfuse_data.value;
     int32_t name = args->com_setfuse_data.name;
 
     /* only ADC_AVR32 seems to support fuse operation */
-    if( !(ADC_AVR32 & args->device_type) || (GRP_STM32 & args->device_type) ) {
-        fprintf( stderr,  "Operation not supported on %s\n",
-                args->device_type_string );
-        DEBUG( "target doesn't support fuse set operation.\n" );
+    if (!(ADC_AVR32 & args->device_type) || (GRP_STM32 & args->device_type)) {
+        fprintf (stderr, "Operation not supported on %s\n", args->device_type_string);
+        DEBUG ("target doesn't support fuse set operation.\n");
         return -1;
     }
 
     /* Check AVR32 security bit in order to provide a better error message. */
-    security_check( device );
+    security_check (device);
 
-    if( 0 != atmel_set_fuse(device, name, value) ) {
-        DEBUG( "Fuse set failed.\n" );
-        fprintf( stderr, "Fuse set failed.\n" );
-        security_message( device );
+    if (0 != atmel_set_fuse (device, name, value)) {
+        DEBUG ("Fuse set failed.\n");
+        fprintf (stderr, "Fuse set failed.\n");
+        security_message (device);
         return -1;
     }
 
     return 0;
 }
 
-static int32_t execute_configure( dfu_device_t *device,
-                                  struct programmer_arguments *args ) {
+static int32_t
+execute_configure (dfu_device_t *device, struct programmer_arguments *args) {
     int32_t value = args->com_configure_data.value;
     int32_t name = args->com_configure_data.name;
 
-    if( ADC_8051 != args->device_type ) {
-        fprintf( stderr, "Operation not supported on %s\n",
-                args->device_type_string );
-        DEBUG( "target doesn't support configure operation.\n" );
+    if (ADC_8051 != args->device_type) {
+        fprintf (stderr, "Operation not supported on %s\n", args->device_type_string);
+        DEBUG ("target doesn't support configure operation.\n");
         return -1;
     }
 
-    if( (0xff & value) != value ) {
-        DEBUG( "Value to configure must be in range 0-255.\n" );
-        fprintf( stderr, "Value to configure must be in range 0-255.\n" );
+    if ((0xff & value) != value) {
+        DEBUG ("Value to configure must be in range 0-255.\n");
+        fprintf (stderr, "Value to configure must be in range 0-255.\n");
         return -1;
     }
 
-    if( 0 != atmel_set_config(device, name, value) )
-    {
-        DEBUG( "Configuration set failed.\n" );
-        fprintf( stderr, "Configuration set failed.\n" );
+    if (0 != atmel_set_config (device, name, value)) {
+        DEBUG ("Configuration set failed.\n");
+        fprintf (stderr, "Configuration set failed.\n");
         return -1;
     }
 
     return 0;
 }
 
-static int32_t execute_launch( dfu_device_t *device,
-                                  struct programmer_arguments *args ) {
-    if( args->device_type & GRP_STM32 ) {
-        return stm32_start_app( device, args->quiet );
-    } else if( args->com_launch_config.noreset ) {
-        return atmel_start_app_noreset( device );
+static int32_t
+execute_launch (dfu_device_t *device, struct programmer_arguments *args) {
+    if (args->device_type & GRP_STM32) {
+        return stm32_start_app (device, args->quiet);
+    } else if (args->com_launch_config.noreset) {
+        return atmel_start_app_noreset (device);
     } else {
-        return atmel_start_app_reset( device );
+        return atmel_start_app_reset (device);
     }
 }
 
-int32_t execute_command( dfu_device_t *device,
-                         struct programmer_arguments *args ) {
+int32_t
+execute_command (dfu_device_t *device, struct programmer_arguments *args) {
     device->type = args->device_type;
-    switch( args->command ) {
-        case com_erase:
-            return execute_erase( device, args );
-        case com_flash:
-            return execute_flash( device, args );
-        case com_eflash:
-            args->com_flash_data.segment = mem_eeprom;
-            args->command = com_launch;
-            return execute_flash( device, args );
-        case com_user:
-            args->com_flash_data.segment = mem_user;
-            args->command = com_launch;
-            return execute_flash( device, args );
-        case com_start_app:
-            args->com_launch_config.noreset = true;
-        case com_reset:
-            args->command = com_launch;
-        case com_launch:
-            return execute_launch( device, args );
-        case com_get:
-            return execute_get( device, args );
-        case com_getfuse:
-            return execute_getfuse( device, args );
-        case com_dump:
-            args->command = com_read;
-            args->com_read_data.force = true;
-            args->com_read_data.bin = 1;
-            return execute_dump( device, args );
-        case com_edump:
-            args->com_read_data.segment = mem_eeprom;
-            args->com_read_data.force = true;
-            args->command = com_read;
-            args->com_read_data.bin = 1;
-            return execute_dump( device, args );
-        case com_udump:
-            args->com_read_data.segment = mem_eeprom;
-            args->com_read_data.force = true;
-            args->command = com_read;
-            args->com_read_data.bin = 1;
-            return execute_dump( device, args );
-        case com_read:
-            return execute_dump( device, args );
-        case com_configure:
-            return execute_configure( device, args );
-        case com_setfuse:
-            return execute_setfuse( device, args );
-        case com_setsecure:
-            return execute_setsecure( device, args );
-        default:
-            fprintf( stderr, "Not supported at this time.\n" );
+    switch (args->command) {
+    case com_erase: return execute_erase (device, args);
+    case com_flash: return execute_flash (device, args);
+    case com_eflash:
+        args->com_flash_data.segment = mem_eeprom;
+        args->command = com_launch;
+        return execute_flash (device, args);
+    case com_user:
+        args->com_flash_data.segment = mem_user;
+        args->command = com_launch;
+        return execute_flash (device, args);
+    case com_start_app: args->com_launch_config.noreset = true;
+    case com_reset: args->command = com_launch;
+    case com_launch: return execute_launch (device, args);
+    case com_get: return execute_get (device, args);
+    case com_getfuse: return execute_getfuse (device, args);
+    case com_dump:
+        args->command = com_read;
+        args->com_read_data.force = true;
+        args->com_read_data.bin = 1;
+        return execute_dump (device, args);
+    case com_edump:
+        args->com_read_data.segment = mem_eeprom;
+        args->com_read_data.force = true;
+        args->command = com_read;
+        args->com_read_data.bin = 1;
+        return execute_dump (device, args);
+    case com_udump:
+        args->com_read_data.segment = mem_eeprom;
+        args->com_read_data.force = true;
+        args->command = com_read;
+        args->com_read_data.bin = 1;
+        return execute_dump (device, args);
+    case com_read: return execute_dump (device, args);
+    case com_configure: return execute_configure (device, args);
+    case com_setfuse: return execute_setfuse (device, args);
+    case com_setsecure: return execute_setsecure (device, args);
+    default: fprintf (stderr, "Not supported at this time.\n");
     }
 
     return ARGUMENT_ERROR;

--- a/src/commands.h
+++ b/src/commands.h
@@ -21,10 +21,9 @@
 #ifndef __COMMANDS_H__
 #define __COMMANDS_H__
 
-#include <stdint.h>
 #include "arguments.h"
 #include "dfu-device.h"
+#include <stdint.h>
 
-int32_t execute_command( dfu_device_t *device,
-                         struct programmer_arguments *args );
+int32_t execute_command (dfu_device_t *device, struct programmer_arguments *args);
 #endif

--- a/src/dfu-device.h
+++ b/src/dfu-device.h
@@ -1,21 +1,21 @@
 #ifndef __DFU_DEVICE_H__
 #define __DFU_DEVICE_H__
 
-#include <stdint.h>
 #include <libusb-1.0/libusb.h>
+#include <stdint.h>
 
 // Atmel device classes are now defined with one bit per class.
 // This simplifies checking in functions which handle more than one class.
-#define ADC_8051    (1<<0)
-#define ADC_AVR     (1<<1)
-#define ADC_AVR32   (1<<2)
-#define ADC_XMEGA   (1<<3)
-#define DC_STM32    (1<<4)
+#define ADC_8051  (1 << 0)
+#define ADC_AVR   (1 << 1)
+#define ADC_AVR32 (1 << 2)
+#define ADC_XMEGA (1 << 3)
+#define DC_STM32  (1 << 4)
 
 // Most commands fall into one of 2 groups.
-#define GRP_AVR32   (ADC_AVR32 | ADC_XMEGA)
-#define GRP_AVR     (ADC_AVR | ADC_8051)
-#define GRP_STM32   (DC_STM32)
+#define GRP_AVR32 (ADC_AVR32 | ADC_XMEGA)
+#define GRP_AVR   (ADC_AVR | ADC_8051)
+#define GRP_STM32 (DC_STM32)
 
 typedef unsigned atmel_device_class_t;
 
@@ -129,7 +129,6 @@ LEAVE DFU MODE      - DFU_DNLOAD with 0 data length
 - see an2606: STM32 microcontroller system memory boot mode
 - see an3156: USB DFU protocol used in the STM32 bootloader
 **************************************************************************/
-
 
 /******************* A T M E L   D F U   C O M M A N D S ******************
 // ---- A L L   D E V I C E S -----------------------------------

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -18,14 +18,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <stddef.h>
-#include <libusb-1.0/libusb.h>
 #include <errno.h>
+#include <libusb-1.0/libusb.h>
+#include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "dfu.h"
 #include "util.h"
@@ -33,16 +33,16 @@
 // cSpell:words DNBUSY
 
 /* DFU commands */
-#define DFU_DETACH      0
-#define DFU_DNLOAD      1
-#define DFU_UPLOAD      2
-#define DFU_GETSTATUS   3
-#define DFU_CLRSTATUS   4
-#define DFU_GETSTATE    5
-#define DFU_ABORT       6
+#define DFU_DETACH    0
+#define DFU_DNLOAD    1
+#define DFU_UPLOAD    2
+#define DFU_GETSTATUS 3
+#define DFU_CLRSTATUS 4
+#define DFU_GETSTATE  5
+#define DFU_ABORT     6
 
-#define USB_CLASS_APP_SPECIFIC  0xfe
-#define DFU_SUBCLASS            0x01
+#define USB_CLASS_APP_SPECIFIC 0xfe
+#define DFU_SUBCLASS           0x01
 
 /* Wait for 20 seconds before a timeout since erasing/flashing can take some time.
  * The longest erase cycle is for the AT32UC3A0512-TA automotive part,
@@ -57,16 +57,12 @@
 #define DFU_TRACE_THRESHOLD         200
 #define DFU_MESSAGE_DEBUG_THRESHOLD 300
 
-#define DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
-                               DFU_DEBUG_THRESHOLD, __VA_ARGS__ )
-#define TRACE(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
-                               DFU_TRACE_THRESHOLD, __VA_ARGS__ )
-#define MSG_DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
-                               DFU_MESSAGE_DEBUG_THRESHOLD, __VA_ARGS__ )
+#define DEBUG(...)     dfu_debug (__FILE__, __FUNCTION__, __LINE__, DFU_DEBUG_THRESHOLD, __VA_ARGS__)
+#define TRACE(...)     dfu_debug (__FILE__, __FUNCTION__, __LINE__, DFU_TRACE_THRESHOLD, __VA_ARGS__)
+#define MSG_DEBUG(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, DFU_MESSAGE_DEBUG_THRESHOLD, __VA_ARGS__)
 
 // ________  P R O T O T Y P E S  _______________________________
-static int32_t dfu_find_interface( struct libusb_device *device,
-                                   const bool honor_interfaceclass,
+static int32_t dfu_find_interface (struct libusb_device *device, const bool honor_interfaceclass,
                                    const uint8_t bNumConfigurations);
 /*  Used to find the dfu interface for a device if there is one.
  *
@@ -77,7 +73,7 @@ static int32_t dfu_find_interface( struct libusb_device *device,
  *  returns the interface number if found, < 0 otherwise
  */
 
-static int32_t dfu_make_idle( dfu_device_t *device, const bool initial_abort );
+static int32_t dfu_make_idle (dfu_device_t *device, const bool initial_abort);
 /*  Gets the device into the dfuIDLE state if possible.
  *
  *  device    - the dfu device to communicate with
@@ -85,19 +81,13 @@ static int32_t dfu_make_idle( dfu_device_t *device, const bool initial_abort );
  *  returns 0 on success, 1 if device was reset, error otherwise
  */
 
-static int32_t dfu_transfer_out( dfu_device_t *device,
-                                 uint8_t request,
-                                 const int32_t value,
-                                 uint8_t* data,
-                                 const size_t length );
+static int32_t dfu_transfer_out (dfu_device_t *device, uint8_t request, const int32_t value, uint8_t *data,
+                                 const size_t length);
 
-static int32_t dfu_transfer_in( dfu_device_t *device,
-                                uint8_t request,
-                                const int32_t value,
-                                uint8_t* data,
-                                const size_t length );
+static int32_t dfu_transfer_in (dfu_device_t *device, uint8_t request, const int32_t value, uint8_t *data,
+                                const size_t length);
 
-static void dfu_msg_response_output( const char *function, const int32_t result );
+static void dfu_msg_response_output (const char *function, const int32_t result);
 /*  Used to output the response from our USB request in a human readable
  *  form.
  *
@@ -106,136 +96,134 @@ static void dfu_msg_response_output( const char *function, const int32_t result 
  */
 
 // ________  F U N C T I O N S  _______________________________
-void dfu_set_transaction_num( dfu_device_t *device, uint16_t newNum ) {
-    TRACE( "%s( %u )\n", __FUNCTION__, newNum );
+void
+dfu_set_transaction_num (dfu_device_t *device, uint16_t newNum) {
+    TRACE ("%s( %u )\n", __FUNCTION__, newNum);
     device->transaction = newNum;
-    DEBUG("wValue set to %d\n", device->transaction);
+    DEBUG ("wValue set to %d\n", device->transaction);
 }
 
-uint16_t dfu_get_transaction_num( dfu_device_t *device ) {
-    TRACE( "%s( %u )\n", __FUNCTION__ );
+uint16_t
+dfu_get_transaction_num (dfu_device_t *device) {
+    TRACE ("%s( %u )\n", __FUNCTION__);
     return device->transaction;
 }
 
-int32_t dfu_detach( dfu_device_t *device, const int32_t timeout ) {
+int32_t
+dfu_detach (dfu_device_t *device, const int32_t timeout) {
     int32_t result;
 
-    TRACE( "%s( %p, %d )\n", __FUNCTION__, device, timeout );
+    TRACE ("%s( %p, %d )\n", __FUNCTION__, device, timeout);
 
-    if( (NULL == device) || (NULL == device->handle) || (timeout < 0) ) {
-        DEBUG( "Invalid parameter\n" );
+    if ((NULL == device) || (NULL == device->handle) || (timeout < 0)) {
+        DEBUG ("Invalid parameter\n");
         return -1;
     }
 
-    result = dfu_transfer_out( device, DFU_DETACH, timeout, NULL, 0 );
+    result = dfu_transfer_out (device, DFU_DETACH, timeout, NULL, 0);
 
-    dfu_msg_response_output( __FUNCTION__, result );
+    dfu_msg_response_output (__FUNCTION__, result);
 
     return result;
 }
 
-int32_t dfu_download( dfu_device_t *device,
-                      const size_t length,
-                      uint8_t* data ) {
+int32_t
+dfu_download (dfu_device_t *device, const size_t length, uint8_t *data) {
     int32_t result;
 
-    TRACE( "%s( %p, %u, %p )\n", __FUNCTION__, device, length, data );
+    TRACE ("%s( %p, %u, %p )\n", __FUNCTION__, device, length, data);
 
     /* Sanity checks */
-    if( (NULL == device) || (NULL == device->handle) ) {
-        DEBUG( "Invalid parameter\n" );
+    if ((NULL == device) || (NULL == device->handle)) {
+        DEBUG ("Invalid parameter\n");
         return -1;
     }
 
-    if( (0 != length) && (NULL == data) ) {
-        DEBUG( "data was NULL, but length != 0\n" );
+    if ((0 != length) && (NULL == data)) {
+        DEBUG ("data was NULL, but length != 0\n");
         return -2;
     }
 
-    if( (0 == length) && (NULL != data) ) {
-        DEBUG( "data was not NULL, but length == 0\n" );
+    if ((0 == length) && (NULL != data)) {
+        DEBUG ("data was not NULL, but length == 0\n");
         return -3;
     }
 
     {
         size_t i;
-        for( i = 0; i < length; i++ ) {
-            MSG_DEBUG( "Message: m[%u] = 0x%02x\n", i, data[i] );
-        }
+        for (i = 0; i < length; i++) { MSG_DEBUG ("Message: m[%u] = 0x%02x\n", i, data[i]); }
     }
 
-    result = dfu_transfer_out( device, DFU_DNLOAD, device->transaction++, data, length );
+    result = dfu_transfer_out (device, DFU_DNLOAD, device->transaction++, data, length);
 
-    dfu_msg_response_output( __FUNCTION__, result );
+    dfu_msg_response_output (__FUNCTION__, result);
 
     return result;
 }
 
-int32_t dfu_upload( dfu_device_t *device, const size_t length, uint8_t* data ) {
+int32_t
+dfu_upload (dfu_device_t *device, const size_t length, uint8_t *data) {
     int32_t result;
 
-    TRACE( "%s( %p, %u, %p )\n", __FUNCTION__, device, length, data );
+    TRACE ("%s( %p, %u, %p )\n", __FUNCTION__, device, length, data);
 
     /* Sanity checks */
-    if( (NULL == device) || (NULL == device->handle) ) {
-        DEBUG( "Invalid parameter\n" );
+    if ((NULL == device) || (NULL == device->handle)) {
+        DEBUG ("Invalid parameter\n");
         return -1;
     }
 
-    if( (0 == length) || (NULL == data) ) {
-        DEBUG( "data was NULL, or length is 0\n" );
+    if ((0 == length) || (NULL == data)) {
+        DEBUG ("data was NULL, or length is 0\n");
         return -2;
     }
 
-    result = dfu_transfer_in( device, DFU_UPLOAD, device->transaction++, data, length );
+    result = dfu_transfer_in (device, DFU_UPLOAD, device->transaction++, data, length);
 
-    dfu_msg_response_output( __FUNCTION__, result );
+    dfu_msg_response_output (__FUNCTION__, result);
 
     return result;
 }
 
-int32_t dfu_get_status( dfu_device_t *device, dfu_status_t *status ) {
+int32_t
+dfu_get_status (dfu_device_t *device, dfu_status_t *status) {
     uint8_t buffer[6];
     int32_t result;
 
-    TRACE( "%s( %p, %p )\n", __FUNCTION__, device, status );
+    TRACE ("%s( %p, %p )\n", __FUNCTION__, device, status);
 
-    if( (NULL == device) || (NULL == device->handle) ) {
-        DEBUG( "Invalid parameter\n" );
+    if ((NULL == device) || (NULL == device->handle)) {
+        DEBUG ("Invalid parameter\n");
         return -1;
     }
 
     /* Initialize the status data structure */
-    status->bStatus       = DFU_STATUS_ERROR_UNKNOWN;
+    status->bStatus = DFU_STATUS_ERROR_UNKNOWN;
     status->bwPollTimeout = 0;
-    status->bState        = STATE_DFU_ERROR;
-    status->iString       = 0;
+    status->bState = STATE_DFU_ERROR;
+    status->iString = 0;
 
-    result = dfu_transfer_in( device, DFU_GETSTATUS, 0, buffer, sizeof(buffer) );
+    result = dfu_transfer_in (device, DFU_GETSTATUS, 0, buffer, sizeof (buffer));
 
-    dfu_msg_response_output( __FUNCTION__, result );
+    dfu_msg_response_output (__FUNCTION__, result);
 
-    if( 6 == result ) {
+    if (6 == result) {
         status->bStatus = buffer[0];
-        status->bwPollTimeout = ((0xff & buffer[3]) << 16) |
-                                ((0xff & buffer[2]) << 8)  |
-                                (0xff & buffer[1]);
+        status->bwPollTimeout = ((0xff & buffer[3]) << 16) | ((0xff & buffer[2]) << 8) | (0xff & buffer[1]);
 
-        status->bState  = buffer[4];
+        status->bState = buffer[4];
         status->iString = buffer[5];
 
-        DEBUG( "==============================\n" );
-        DEBUG( "status->bStatus: %s (0x%02x)\n",
-               dfu_status_to_string(status->bStatus), status->bStatus );
-        DEBUG( "status->bwPollTimeout: 0x%04x ms\n", status->bwPollTimeout );
-        DEBUG( "status->bState: %s (0x%02x)\n",
-               dfu_state_to_string(status->bState), status->bState );
-        DEBUG( "status->iString: 0x%02x\n", status->iString );
-        DEBUG( "------------------------------\n" );
+        DEBUG ("==============================\n");
+        DEBUG ("status->bStatus: %s (0x%02x)\n", dfu_status_to_string (status->bStatus), status->bStatus);
+        DEBUG ("status->bwPollTimeout: 0x%04x ms\n", status->bwPollTimeout);
+        DEBUG ("status->bState: %s (0x%02x)\n", dfu_state_to_string (status->bState), status->bState);
+        DEBUG ("status->iString: 0x%02x\n", status->iString);
+        DEBUG ("------------------------------\n");
     } else {
-        if( 0 < result ) {
+        if (0 < result) {
             /* There was an error, we didn't get the entire message. */
-            DEBUG( "result: %d\n", result );
+            DEBUG ("result: %d\n", result);
             return -2;
         }
     }
@@ -243,484 +231,383 @@ int32_t dfu_get_status( dfu_device_t *device, dfu_status_t *status ) {
     return 0;
 }
 
-int32_t dfu_clear_status( dfu_device_t *device ) {
+int32_t
+dfu_clear_status (dfu_device_t *device) {
     int32_t result;
 
-    TRACE( "%s( %p )\n", __FUNCTION__, device );
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
 
-    if( (NULL == device) || (NULL == device->handle) ) {
-        DEBUG( "Invalid parameter\n" );
+    if ((NULL == device) || (NULL == device->handle)) {
+        DEBUG ("Invalid parameter\n");
         return -1;
     }
 
-    result = dfu_transfer_out( device, DFU_CLRSTATUS, 0, NULL, 0 );
+    result = dfu_transfer_out (device, DFU_CLRSTATUS, 0, NULL, 0);
 
-    dfu_msg_response_output( __FUNCTION__, result );
+    dfu_msg_response_output (__FUNCTION__, result);
 
     return result;
 }
 
-int32_t dfu_get_state( dfu_device_t *device ) {
+int32_t
+dfu_get_state (dfu_device_t *device) {
     int32_t result;
     uint8_t buffer[1];
 
-    TRACE( "%s( %p )\n", __FUNCTION__, device );
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
 
-    if( (NULL == device) || (NULL == device->handle) ) {
-        DEBUG( "Invalid parameter\n" );
+    if ((NULL == device) || (NULL == device->handle)) {
+        DEBUG ("Invalid parameter\n");
         return -1;
     }
 
-    result = dfu_transfer_in( device, DFU_GETSTATE, 0, buffer, sizeof(buffer) );
+    result = dfu_transfer_in (device, DFU_GETSTATE, 0, buffer, sizeof (buffer));
 
-    dfu_msg_response_output( __FUNCTION__, result );
+    dfu_msg_response_output (__FUNCTION__, result);
 
     /* Return the error if there is one. */
-    if( result < 1 ) {
-        return result;
-    }
+    if (result < 1) { return result; }
 
     /* Return the state. */
     return buffer[0];
 }
 
-int32_t dfu_abort( dfu_device_t *device ) {
+int32_t
+dfu_abort (dfu_device_t *device) {
     int32_t result;
 
-    TRACE( "%s( %p )\n", __FUNCTION__, device );
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
 
-    if( (NULL == device) || (NULL == device->handle) ) {
-        DEBUG( "Invalid parameter\n" );
+    if ((NULL == device) || (NULL == device->handle)) {
+        DEBUG ("Invalid parameter\n");
         return -1;
     }
 
-    result = dfu_transfer_out( device, DFU_ABORT, 0, NULL, 0 );
+    result = dfu_transfer_out (device, DFU_ABORT, 0, NULL, 0);
 
-    dfu_msg_response_output( __FUNCTION__, result );
+    dfu_msg_response_output (__FUNCTION__, result);
 
     return result;
 }
 
-struct libusb_device *dfu_device_init( const uint32_t vendor,
-                                       const uint32_t product,
-                                       const uint32_t bus_number,
-                                       const uint32_t device_address,
-                                       dfu_device_t *dfu_device,
-                                       const bool initial_abort,
-                                       const bool honor_interfaceclass ) {
+struct libusb_device *
+dfu_device_init (const uint32_t vendor, const uint32_t product, const uint32_t bus_number,
+                 const uint32_t device_address, dfu_device_t *dfu_device, const bool initial_abort,
+                 const bool honor_interfaceclass) {
     libusb_device **list;
-    size_t i,deviceCount;
+    size_t i, deviceCount;
     extern libusb_context *usbContext;
     int32_t retries = 4;
 
-    TRACE( "%s( %u, %u, %p, %s, %s )\n", __FUNCTION__, vendor, product,
-           dfu_device, ((true == initial_abort) ? "true" : "false"),
-           ((true == honor_interfaceclass) ? "true" : "false") );
+    TRACE ("%s( %u, %u, %p, %s, %s )\n", __FUNCTION__, vendor, product, dfu_device,
+           ((true == initial_abort) ? "true" : "false"), ((true == honor_interfaceclass) ? "true" : "false"));
 
-    DEBUG( "%s(%08x, %08x)\n",__FUNCTION__, vendor, product );
+    DEBUG ("%s(%08x, %08x)\n", __FUNCTION__, vendor, product);
 
 retry:
-    deviceCount = libusb_get_device_list( usbContext, &list );
+    deviceCount = libusb_get_device_list (usbContext, &list);
 
-    for( i = 0; i < deviceCount; i++ ) {
+    for (i = 0; i < deviceCount; i++) {
         libusb_device *device = list[i];
         struct libusb_device_descriptor descriptor;
 
-        if( libusb_get_device_descriptor(device, &descriptor) ) {
-             DEBUG( "Failed in libusb_get_device_descriptor\n" );
-             break;
+        if (libusb_get_device_descriptor (device, &descriptor)) {
+            DEBUG ("Failed in libusb_get_device_descriptor\n");
+            break;
         }
 
-        DEBUG( "%2d: 0x%04x, 0x%04x\n", (int) i, descriptor.idVendor, descriptor.idProduct );
+        DEBUG ("%2d: 0x%04x, 0x%04x\n", (int)i, descriptor.idVendor, descriptor.idProduct);
 
-        if( vendor  != descriptor.idVendor) continue;
-        if( product != descriptor.idProduct) continue;
+        if (vendor != descriptor.idVendor) continue;
+        if (product != descriptor.idProduct) continue;
 
-        if( bus_number != 0 ) {
-            if ( libusb_get_bus_number(device) != bus_number ) continue;
-            if ( libusb_get_device_address(device) != device_address ) continue;
+        if (bus_number != 0) {
+            if (libusb_get_bus_number (device) != bus_number) continue;
+            if (libusb_get_device_address (device) != device_address) continue;
         }
-        
+
         int32_t tmp;
-        DEBUG( "found device at USB:%d,%d\n", libusb_get_bus_number(device), libusb_get_device_address(device) );
+        DEBUG ("found device at USB:%d,%d\n", libusb_get_bus_number (device), libusb_get_device_address (device));
         // We found a device that looks like it matches...
         // Let's try to find the DFU interface, open the device and claim it.
 
-        tmp = dfu_find_interface( device, honor_interfaceclass, descriptor.bNumConfigurations );
+        tmp = dfu_find_interface (device, honor_interfaceclass, descriptor.bNumConfigurations);
 
         if (tmp < 0) {
             /* The interface is invalid. */
-            DEBUG( "Failed to find interface.\n" );
+            DEBUG ("Failed to find interface.\n");
             continue;
         }
 
         dfu_device->interface = tmp;
 
-        DEBUG( "opening interface %d...\n", tmp );
+        DEBUG ("opening interface %d...\n", tmp);
 
-        tmp = libusb_open( device, &dfu_device->handle );
+        tmp = libusb_open (device, &dfu_device->handle);
 
-        DEBUG( "returned %d...\n", tmp );
+        DEBUG ("returned %d...\n", tmp);
 
         if (tmp) {
-            DEBUG( "failed to open device\n" );
+            DEBUG ("failed to open device\n");
             continue;
         }
 
-        DEBUG( "opened interface %d...\n", tmp );
+        DEBUG ("opened interface %d...\n", tmp);
 
-        tmp = libusb_set_configuration( dfu_device->handle, 1 );
+        tmp = libusb_set_configuration (dfu_device->handle, 1);
 
         if (tmp) {
-            DEBUG( "Failed to set configuration.\n" );
+            DEBUG ("Failed to set configuration.\n");
             goto done;
         }
 
-        DEBUG( "set configuration %d...\n", 1 );
+        DEBUG ("set configuration %d...\n", 1);
 
-        tmp = libusb_claim_interface( dfu_device->handle, dfu_device->interface );
+        tmp = libusb_claim_interface (dfu_device->handle, dfu_device->interface);
 
         if (tmp) {
-            DEBUG( "Failed to claim the DFU interface.\n" );
+            DEBUG ("Failed to claim the DFU interface.\n");
             goto done;
         }
 
-        DEBUG( "claimed interface %d...\n", dfu_device->interface );
+        DEBUG ("claimed interface %d...\n", dfu_device->interface);
 
-        tmp = dfu_make_idle( dfu_device, initial_abort );
+        tmp = dfu_make_idle (dfu_device, initial_abort);
 
         if (tmp == 0 || tmp == 1) {
-            libusb_free_device_list( list, 1 );
-            if (!tmp) {
-                return device;
-            }
-            
+            libusb_free_device_list (list, 1);
+            if (!tmp) { return device; }
+
             retries--;
             goto retry;
         }
 
-        DEBUG( "Failed to put the device in dfuIDLE mode.\n" );
-        libusb_release_interface( dfu_device->handle, dfu_device->interface );
+        DEBUG ("Failed to put the device in dfuIDLE mode.\n");
+        libusb_release_interface (dfu_device->handle, dfu_device->interface);
         retries = 4;
 
-        done:
-        libusb_close( dfu_device->handle );
-        
+    done:
+        libusb_close (dfu_device->handle);
     }
 
-    libusb_free_device_list( list, 1 );
+    libusb_free_device_list (list, 1);
     dfu_device->handle = NULL;
     dfu_device->interface = 0;
 
     return NULL;
 }
 
-char* dfu_state_to_string( const int32_t state ) {
+char *
+dfu_state_to_string (const int32_t state) {
     char *message = "unknown state";
 
-    switch( state ) {
-        case STATE_APP_IDLE:
-            message = "appIDLE";
-            break;
-        case STATE_APP_DETACH:
-            message = "appDETACH";
-            break;
-        case STATE_DFU_IDLE:
-            message = "dfuIDLE";
-            break;
-        case STATE_DFU_DOWNLOAD_SYNC:
-            message = "dfuDNLOAD-SYNC";
-            break;
-        case STATE_DFU_DOWNLOAD_BUSY:
-            message = "dfuDNBUSY";
-            break;
-        case STATE_DFU_DOWNLOAD_IDLE:
-            message = "dfuDNLOAD-IDLE";
-            break;
-        case STATE_DFU_MANIFEST_SYNC:
-            message = "dfuMANIFEST-SYNC";
-            break;
-        case STATE_DFU_MANIFEST:
-            message = "dfuMANIFEST";
-            break;
-        case STATE_DFU_MANIFEST_WAIT_RESET:
-            message = "dfuMANIFEST-WAIT-RESET";
-            break;
-        case STATE_DFU_UPLOAD_IDLE:
-            message = "dfuUPLOAD-IDLE";
-            break;
-        case STATE_DFU_ERROR:
-            message = "dfuERROR";
-            break;
+    switch (state) {
+    case STATE_APP_IDLE: message = "appIDLE"; break;
+    case STATE_APP_DETACH: message = "appDETACH"; break;
+    case STATE_DFU_IDLE: message = "dfuIDLE"; break;
+    case STATE_DFU_DOWNLOAD_SYNC: message = "dfuDNLOAD-SYNC"; break;
+    case STATE_DFU_DOWNLOAD_BUSY: message = "dfuDNBUSY"; break;
+    case STATE_DFU_DOWNLOAD_IDLE: message = "dfuDNLOAD-IDLE"; break;
+    case STATE_DFU_MANIFEST_SYNC: message = "dfuMANIFEST-SYNC"; break;
+    case STATE_DFU_MANIFEST: message = "dfuMANIFEST"; break;
+    case STATE_DFU_MANIFEST_WAIT_RESET: message = "dfuMANIFEST-WAIT-RESET"; break;
+    case STATE_DFU_UPLOAD_IDLE: message = "dfuUPLOAD-IDLE"; break;
+    case STATE_DFU_ERROR: message = "dfuERROR"; break;
     }
 
     return message;
 }
 
-char* dfu_status_to_string( const int32_t status ) {
+char *
+dfu_status_to_string (const int32_t status) {
     char *message = "unknown status";
 
-    switch( status ) {
-        case DFU_STATUS_OK:
-            message = "OK";
-            break;
-        case DFU_STATUS_ERROR_TARGET:
-            message = "errTARGET";
-            break;
-        case DFU_STATUS_ERROR_FILE:
-            message = "errFILE";
-            break;
-        case DFU_STATUS_ERROR_WRITE:
-            message = "errWRITE";
-            break;
-        case DFU_STATUS_ERROR_ERASE:
-            message = "errERASE";
-            break;
-        case DFU_STATUS_ERROR_CHECK_ERASED:
-            message = "errCHECK_ERASED";
-            break;
-        case DFU_STATUS_ERROR_PROG:
-            message = "errPROG";
-            break;
-        case DFU_STATUS_ERROR_VERIFY:
-            message = "errVERIFY";
-            break;
-        case DFU_STATUS_ERROR_ADDRESS:
-            message = "errADDRESS";
-            break;
-        case DFU_STATUS_ERROR_NOTDONE:
-            message = "errNOTDONE";
-            break;
-        case DFU_STATUS_ERROR_FIRMWARE:
-            message = "errFIRMWARE";
-            break;
-        case DFU_STATUS_ERROR_VENDOR:
-            message = "errVENDOR";
-            break;
-        case DFU_STATUS_ERROR_USBR:
-            message = "errUSBR";
-            break;
-        case DFU_STATUS_ERROR_POR:
-            message = "errPOR";
-            break;
-        case DFU_STATUS_ERROR_UNKNOWN:
-            message = "errUNKNOWN";
-            break;
-        case DFU_STATUS_ERROR_STALLEDPKT:
-            message = "errSTALLEDPKT";
-            break;
+    switch (status) {
+    case DFU_STATUS_OK: message = "OK"; break;
+    case DFU_STATUS_ERROR_TARGET: message = "errTARGET"; break;
+    case DFU_STATUS_ERROR_FILE: message = "errFILE"; break;
+    case DFU_STATUS_ERROR_WRITE: message = "errWRITE"; break;
+    case DFU_STATUS_ERROR_ERASE: message = "errERASE"; break;
+    case DFU_STATUS_ERROR_CHECK_ERASED: message = "errCHECK_ERASED"; break;
+    case DFU_STATUS_ERROR_PROG: message = "errPROG"; break;
+    case DFU_STATUS_ERROR_VERIFY: message = "errVERIFY"; break;
+    case DFU_STATUS_ERROR_ADDRESS: message = "errADDRESS"; break;
+    case DFU_STATUS_ERROR_NOTDONE: message = "errNOTDONE"; break;
+    case DFU_STATUS_ERROR_FIRMWARE: message = "errFIRMWARE"; break;
+    case DFU_STATUS_ERROR_VENDOR: message = "errVENDOR"; break;
+    case DFU_STATUS_ERROR_USBR: message = "errUSBR"; break;
+    case DFU_STATUS_ERROR_POR: message = "errPOR"; break;
+    case DFU_STATUS_ERROR_UNKNOWN: message = "errUNKNOWN"; break;
+    case DFU_STATUS_ERROR_STALLEDPKT: message = "errSTALLEDPKT"; break;
     }
     return message;
 }
 
-static int32_t dfu_find_interface( struct libusb_device *device,
-                                   const bool honor_interfaceclass,
-                                   const uint8_t bNumConfigurations) {
-    int32_t c,i,s;
+static int32_t
+dfu_find_interface (struct libusb_device *device, const bool honor_interfaceclass, const uint8_t bNumConfigurations) {
+    int32_t c, i, s;
 
-    TRACE( "%s()\n", __FUNCTION__ );
+    TRACE ("%s()\n", __FUNCTION__);
 
     /* Loop through all of the configurations */
-    for( c = 0; c < bNumConfigurations; c++ ) {
+    for (c = 0; c < bNumConfigurations; c++) {
         struct libusb_config_descriptor *config;
 
-        if( libusb_get_config_descriptor(device, c, &config) ) {
-            DEBUG( "can't get_config_descriptor: %d\n", c );
+        if (libusb_get_config_descriptor (device, c, &config)) {
+            DEBUG ("can't get_config_descriptor: %d\n", c);
             return -1;
         }
-        DEBUG( "config %d: MaxPower=%d*2 mA\n", c, config->MaxPower );
+        DEBUG ("config %d: MaxPower=%d*2 mA\n", c, config->MaxPower);
 
         /* Loop through all of the interfaces */
-        for( i = 0; i < config->bNumInterfaces; i++ ) {
+        for (i = 0; i < config->bNumInterfaces; i++) {
             struct libusb_interface interface;
 
             interface = config->interface[i];
-            DEBUG( "interface %d\n", i );
+            DEBUG ("interface %d\n", i);
 
             /* Loop through all of the settings */
-            for( s = 0; s < interface.num_altsetting; s++ ) {
+            for (s = 0; s < interface.num_altsetting; s++) {
                 struct libusb_interface_descriptor setting;
 
                 setting = interface.altsetting[s];
-                DEBUG( "setting %d: class:%d, subclass %d, protocol:%d\n", s,
-                                setting.bInterfaceClass, setting.bInterfaceSubClass,
-                                setting.bInterfaceProtocol );
+                DEBUG ("setting %d: class:%d, subclass %d, protocol:%d\n", s, setting.bInterfaceClass,
+                       setting.bInterfaceSubClass, setting.bInterfaceProtocol);
 
-                if( honor_interfaceclass ) {
+                if (honor_interfaceclass) {
                     /* Check if the interface is a DFU interface */
-                    if(    (USB_CLASS_APP_SPECIFIC == setting.bInterfaceClass)
-                        && (DFU_SUBCLASS == setting.bInterfaceSubClass) )
-                    {
-                        DEBUG( "Found DFU Interface: %d\n", setting.bInterfaceNumber );
+                    if ((USB_CLASS_APP_SPECIFIC == setting.bInterfaceClass)
+                        && (DFU_SUBCLASS == setting.bInterfaceSubClass)) {
+                        DEBUG ("Found DFU Interface: %d\n", setting.bInterfaceNumber);
                         return setting.bInterfaceNumber;
                     }
                 } else {
                     /* If there is a bug in the DFU firmware, return the first
                      * found interface. */
-                    DEBUG( "Found DFU Interface: %d\n", setting.bInterfaceNumber );
+                    DEBUG ("Found DFU Interface: %d\n", setting.bInterfaceNumber);
                     return setting.bInterfaceNumber;
                 }
             }
         }
 
-        libusb_free_config_descriptor( config );
+        libusb_free_config_descriptor (config);
     }
 
     return -1;
 }
 
-
-static int32_t dfu_make_idle( dfu_device_t *device,
-                              const bool initial_abort ) {
+static int32_t
+dfu_make_idle (dfu_device_t *device, const bool initial_abort) {
     dfu_status_t status;
     int32_t retries = 4;
 
-    if( true == initial_abort ) {
-        dfu_abort( device );
-    }
+    if (true == initial_abort) { dfu_abort (device); }
 
-    while( 0 < retries ) {
-        if( 0 != dfu_get_status(device, &status) ) {
-            dfu_clear_status( device );
+    while (0 < retries) {
+        if (0 != dfu_get_status (device, &status)) {
+            dfu_clear_status (device);
             continue;
         }
 
-        DEBUG( "State: %s (%d)\n", dfu_state_to_string(status.bState), status.bState );
+        DEBUG ("State: %s (%d)\n", dfu_state_to_string (status.bState), status.bState);
 
-        switch( status.bState ) {
-            case STATE_DFU_IDLE:
-                if( DFU_STATUS_OK == status.bStatus ) {
-                    return 0;
-                }
+        switch (status.bState) {
+        case STATE_DFU_IDLE:
+            if (DFU_STATUS_OK == status.bStatus) { return 0; }
 
-                /* We need the device to have the DFU_STATUS_OK status. */
-                dfu_clear_status( device );
-                break;
+            /* We need the device to have the DFU_STATUS_OK status. */
+            dfu_clear_status (device);
+            break;
 
-            case STATE_DFU_DOWNLOAD_SYNC:   /* abort -> idle */
-            case STATE_DFU_DOWNLOAD_IDLE:   /* abort -> idle */
-            case STATE_DFU_MANIFEST_SYNC:   /* abort -> idle */
-            case STATE_DFU_UPLOAD_IDLE:     /* abort -> idle */
-            case STATE_DFU_DOWNLOAD_BUSY:   /* abort -> error */
-            case STATE_DFU_MANIFEST:        /* abort -> error */
-                dfu_abort( device );
-                break;
+        case STATE_DFU_DOWNLOAD_SYNC: /* abort -> idle */
+        case STATE_DFU_DOWNLOAD_IDLE: /* abort -> idle */
+        case STATE_DFU_MANIFEST_SYNC: /* abort -> idle */
+        case STATE_DFU_UPLOAD_IDLE:   /* abort -> idle */
+        case STATE_DFU_DOWNLOAD_BUSY: /* abort -> error */
+        case STATE_DFU_MANIFEST: /* abort -> error */ dfu_abort (device); break;
 
-            case STATE_DFU_ERROR:
-                dfu_clear_status( device );
-                break;
+        case STATE_DFU_ERROR: dfu_clear_status (device); break;
 
-            case STATE_APP_IDLE:
-                dfu_detach( device, DFU_DETACH_TIMEOUT );
-                break;
+        case STATE_APP_IDLE: dfu_detach (device, DFU_DETACH_TIMEOUT); break;
 
-            case STATE_APP_DETACH:
-            case STATE_DFU_MANIFEST_WAIT_RESET:
-                DEBUG( "Resetting the device\n" );
-                libusb_reset_device( device->handle );
-                return 1;
+        case STATE_APP_DETACH:
+        case STATE_DFU_MANIFEST_WAIT_RESET:
+            DEBUG ("Resetting the device\n");
+            libusb_reset_device (device->handle);
+            return 1;
         }
 
         retries--;
     }
 
-    DEBUG( "Not able to transition the device into the dfuIDLE state.\n" );
+    DEBUG ("Not able to transition the device into the dfuIDLE state.\n");
     return -2;
 }
 
-static int32_t dfu_transfer_out( dfu_device_t *device,
-                                 uint8_t request,
-                                 const int32_t value,
-                                 uint8_t* data,
-                                 const size_t length ) {
-    return libusb_control_transfer( device->handle,
-                /* bmRequestType */ LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
-                /* bRequest      */ request,
-                /* wValue        */ value,
-                /* wIndex        */ device->interface,
-                /* Data          */ data,
-                /* wLength       */ length,
-                                    DFU_TIMEOUT );
+static int32_t
+dfu_transfer_out (dfu_device_t *device, uint8_t request, const int32_t value, uint8_t *data, const size_t length) {
+    return libusb_control_transfer (device->handle,
+                                    /* bmRequestType */ LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_CLASS
+                                        | LIBUSB_RECIPIENT_INTERFACE,
+                                    /* bRequest      */ request,
+                                    /* wValue        */ value,
+                                    /* wIndex        */ device->interface,
+                                    /* Data          */ data,
+                                    /* wLength       */ length, DFU_TIMEOUT);
 }
 
-static int32_t dfu_transfer_in( dfu_device_t *device,
-                                uint8_t request,
-                                const int32_t value,
-                                uint8_t* data,
-                                const size_t length ) {
-    return libusb_control_transfer( device->handle,
-                /* bmRequestType */ LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
-                /* bRequest      */ request,
-                /* wValue        */ value,
-                /* wIndex        */ device->interface,
-                /* Data          */ data,
-                /* wLength       */ length,
-                                    DFU_TIMEOUT );
+static int32_t
+dfu_transfer_in (dfu_device_t *device, uint8_t request, const int32_t value, uint8_t *data, const size_t length) {
+    return libusb_control_transfer (device->handle,
+                                    /* bmRequestType */ LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_CLASS
+                                        | LIBUSB_RECIPIENT_INTERFACE,
+                                    /* bRequest      */ request,
+                                    /* wValue        */ value,
+                                    /* wIndex        */ device->interface,
+                                    /* Data          */ data,
+                                    /* wLength       */ length, DFU_TIMEOUT);
 }
 
-static void dfu_msg_response_output( const char *function,
-                                     const int32_t result ) {
+static void
+dfu_msg_response_output (const char *function, const int32_t result) {
     char *msg = NULL;
 
-    if( 0 <= result ) {
+    if (0 <= result) {
         msg = "No error.";
     } else {
-        switch( result ) {
-            case LIBUSB_ERROR_IO :
-                msg = "LIBUSB_ERROR_IO: Input/output error.";
-                break;
-            case LIBUSB_ERROR_INVALID_PARAM :
-                msg = "LIBUSB_ERROR_INVALID_PARAM: Invalid parameter.";
-                break;
-            case LIBUSB_ERROR_ACCESS :
-                msg = "LIBUSB_ERROR_ACCESS: Access denied (insufficient permissions)";
-                break;
-            case LIBUSB_ERROR_NO_DEVICE :
-                msg = "LIBUSB_ERROR_NO_DEVICE: No such device (it may have been disconnected)";
-                break;
-            case LIBUSB_ERROR_NOT_FOUND :
-                msg = "LIBUSB_ERROR_NOT_FOUND: Entity not found.";
-                break;
-            case LIBUSB_ERROR_BUSY :
-                msg = "LIBUSB_ERROR_BUSY: Resource busy.";
-                break;
-            case LIBUSB_ERROR_TIMEOUT :
-                msg = "LIBUSB_ERROR_TIMEOUT: Operation timed out.";
-                break;
-            case LIBUSB_ERROR_OVERFLOW :
-                msg = "LIBUSB_ERROR_OVERFLOW: Overflow.";
-                break;
-            case LIBUSB_ERROR_PIPE :
-                msg = "LIBUSB_ERROR_PIPE: Pipe error.";
-                break;
-            case LIBUSB_ERROR_INTERRUPTED :
-                msg = "LIBUSB_ERROR_INTERRUPTED: System call interrupted (perhaps due to signal)";
-                break;
-            case LIBUSB_ERROR_NO_MEM :
-                msg = "LIBUSB_ERROR_NO_MEM: Insufficient memory.";
-                break;
-            case LIBUSB_ERROR_NOT_SUPPORTED :
-                msg = "LIBUSB_ERROR_NOT_SUPPORTED: Operation not supported or unimplemented on this platform.";
-                break;
-            case LIBUSB_ERROR_OTHER :
-                msg = "LIBUSB_ERROR_OTHER: Other error.";
-                break;
+        switch (result) {
+        case LIBUSB_ERROR_IO: msg = "LIBUSB_ERROR_IO: Input/output error."; break;
+        case LIBUSB_ERROR_INVALID_PARAM: msg = "LIBUSB_ERROR_INVALID_PARAM: Invalid parameter."; break;
+        case LIBUSB_ERROR_ACCESS: msg = "LIBUSB_ERROR_ACCESS: Access denied (insufficient permissions)"; break;
+        case LIBUSB_ERROR_NO_DEVICE:
+            msg = "LIBUSB_ERROR_NO_DEVICE: No such device (it may have been disconnected)";
+            break;
+        case LIBUSB_ERROR_NOT_FOUND: msg = "LIBUSB_ERROR_NOT_FOUND: Entity not found."; break;
+        case LIBUSB_ERROR_BUSY: msg = "LIBUSB_ERROR_BUSY: Resource busy."; break;
+        case LIBUSB_ERROR_TIMEOUT: msg = "LIBUSB_ERROR_TIMEOUT: Operation timed out."; break;
+        case LIBUSB_ERROR_OVERFLOW: msg = "LIBUSB_ERROR_OVERFLOW: Overflow."; break;
+        case LIBUSB_ERROR_PIPE: msg = "LIBUSB_ERROR_PIPE: Pipe error."; break;
+        case LIBUSB_ERROR_INTERRUPTED:
+            msg = "LIBUSB_ERROR_INTERRUPTED: System call interrupted (perhaps due to signal)";
+            break;
+        case LIBUSB_ERROR_NO_MEM: msg = "LIBUSB_ERROR_NO_MEM: Insufficient memory."; break;
+        case LIBUSB_ERROR_NOT_SUPPORTED:
+            msg = "LIBUSB_ERROR_NOT_SUPPORTED: Operation not supported or unimplemented on this platform.";
+            break;
+        case LIBUSB_ERROR_OTHER: msg = "LIBUSB_ERROR_OTHER: Other error."; break;
 
-            default:
-                msg = "Unknown error";
-                break;
+        default: msg = "Unknown error"; break;
         }
-        DEBUG( "%s ERR: %s 0x%08x (%d)\n", function, msg, result, result );
+        DEBUG ("%s ERR: %s 0x%08x (%d)\n", function, msg, result, result);
     }
 }
 
 #ifdef malloc
 #undef malloc
-void* rpl_malloc( size_t n ) {
-    if( 0 == n ) {
-        n = 1;
-    }
+void *
+rpl_malloc (size_t n) {
+    if (0 == n) { n = 1; }
 
-    return malloc( n );
+    return malloc (n);
 }
 #endif

--- a/src/dfu.h
+++ b/src/dfu.h
@@ -22,44 +22,42 @@
 #define __DFU_H__
 
 #include <libusb-1.0/libusb.h>
-#include <stdint.h>
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "dfu-device.h"
 
 /* DFU states */
-#define STATE_APP_IDLE                  0x00
-#define STATE_APP_DETACH                0x01
-#define STATE_DFU_IDLE                  0x02
-#define STATE_DFU_DOWNLOAD_SYNC         0x03
-#define STATE_DFU_DOWNLOAD_BUSY         0x04
-#define STATE_DFU_DOWNLOAD_IDLE         0x05
-#define STATE_DFU_MANIFEST_SYNC         0x06
-#define STATE_DFU_MANIFEST              0x07
-#define STATE_DFU_MANIFEST_WAIT_RESET   0x08
-#define STATE_DFU_UPLOAD_IDLE           0x09
-#define STATE_DFU_ERROR                 0x0a
-
+#define STATE_APP_IDLE                0x00
+#define STATE_APP_DETACH              0x01
+#define STATE_DFU_IDLE                0x02
+#define STATE_DFU_DOWNLOAD_SYNC       0x03
+#define STATE_DFU_DOWNLOAD_BUSY       0x04
+#define STATE_DFU_DOWNLOAD_IDLE       0x05
+#define STATE_DFU_MANIFEST_SYNC       0x06
+#define STATE_DFU_MANIFEST            0x07
+#define STATE_DFU_MANIFEST_WAIT_RESET 0x08
+#define STATE_DFU_UPLOAD_IDLE         0x09
+#define STATE_DFU_ERROR               0x0a
 
 /* DFU status */
-#define DFU_STATUS_OK                   0x00
-#define DFU_STATUS_ERROR_TARGET         0x01
-#define DFU_STATUS_ERROR_FILE           0x02
-#define DFU_STATUS_ERROR_WRITE          0x03
-#define DFU_STATUS_ERROR_ERASE          0x04
-#define DFU_STATUS_ERROR_CHECK_ERASED   0x05
-#define DFU_STATUS_ERROR_PROG           0x06
-#define DFU_STATUS_ERROR_VERIFY         0x07
-#define DFU_STATUS_ERROR_ADDRESS        0x08
-#define DFU_STATUS_ERROR_NOTDONE        0x09
-#define DFU_STATUS_ERROR_FIRMWARE       0x0a
-#define DFU_STATUS_ERROR_VENDOR         0x0b
-#define DFU_STATUS_ERROR_USBR           0x0c
-#define DFU_STATUS_ERROR_POR            0x0d
-#define DFU_STATUS_ERROR_UNKNOWN        0x0e
-#define DFU_STATUS_ERROR_STALLEDPKT     0x0f
-
+#define DFU_STATUS_OK                 0x00
+#define DFU_STATUS_ERROR_TARGET       0x01
+#define DFU_STATUS_ERROR_FILE         0x02
+#define DFU_STATUS_ERROR_WRITE        0x03
+#define DFU_STATUS_ERROR_ERASE        0x04
+#define DFU_STATUS_ERROR_CHECK_ERASED 0x05
+#define DFU_STATUS_ERROR_PROG         0x06
+#define DFU_STATUS_ERROR_VERIFY       0x07
+#define DFU_STATUS_ERROR_ADDRESS      0x08
+#define DFU_STATUS_ERROR_NOTDONE      0x09
+#define DFU_STATUS_ERROR_FIRMWARE     0x0a
+#define DFU_STATUS_ERROR_VENDOR       0x0b
+#define DFU_STATUS_ERROR_USBR         0x0c
+#define DFU_STATUS_ERROR_POR          0x0d
+#define DFU_STATUS_ERROR_UNKNOWN      0x0e
+#define DFU_STATUS_ERROR_STALLEDPKT   0x0f
 
 /* This is based off of DFU_GETSTATUS
  *
@@ -67,7 +65,7 @@
  *  3 unsigned byte bwPollTimeout
  *  1 unsigned byte bState
  *  1 unsigned byte iString
-*/
+ */
 
 typedef struct {
     uint8_t bStatus;
@@ -76,17 +74,17 @@ typedef struct {
     uint8_t iString;
 } dfu_status_t;
 
-void dfu_set_transaction_num( dfu_device_t *device, uint16_t newNum );
+void dfu_set_transaction_num (dfu_device_t *device, uint16_t newNum);
 /* set / reset the wValue parameter to a given value. this number is
  * significant for stm32 device commands (see dfu-device.h)
  */
 
-uint16_t dfu_get_transaction_num( dfu_device_t *device );
+uint16_t dfu_get_transaction_num (dfu_device_t *device);
 /* get the current transaction number (can be used to calculate address
  * offset for stm32 devices --- see dfu-device.h)
  */
 
-int32_t dfu_detach( dfu_device_t *device, const int32_t timeout );
+int32_t dfu_detach (dfu_device_t *device, const int32_t timeout);
 /*  DFU_DETACH Request (DFU Spec 1.0, Section 5.1)
  *
  *  device    - the dfu device to communicate with
@@ -96,7 +94,7 @@ int32_t dfu_detach( dfu_device_t *device, const int32_t timeout );
  *  returns 0 or < 0 on error
  */
 
-int32_t dfu_download( dfu_device_t *device, const size_t length, uint8_t* data );
+int32_t dfu_download (dfu_device_t *device, const size_t length, uint8_t *data);
 /*  DFU_DNLOAD Request (DFU Spec 1.0, Section 6.1.1)
  *
  *  device    - the dfu device to communicate with
@@ -107,7 +105,7 @@ int32_t dfu_download( dfu_device_t *device, const size_t length, uint8_t* data )
  *  returns the number of bytes written or < 0 on error
  */
 
-int32_t dfu_upload( dfu_device_t *device, const size_t length, uint8_t* data );
+int32_t dfu_upload (dfu_device_t *device, const size_t length, uint8_t *data);
 /*  DFU_UPLOAD Request (DFU Spec 1.0, Section 6.2)
  *
  *  device    - the dfu device to communicate with
@@ -118,7 +116,7 @@ int32_t dfu_upload( dfu_device_t *device, const size_t length, uint8_t* data );
  *  returns the number of bytes received or < 0 on error
  */
 
-int32_t dfu_get_status( dfu_device_t *device, dfu_status_t *status );
+int32_t dfu_get_status (dfu_device_t *device, dfu_status_t *status);
 /*  DFU_GETSTATUS Request (DFU Spec 1.0, Section 6.1.2)
  *
  *  device    - the dfu device to communicate with
@@ -127,7 +125,7 @@ int32_t dfu_get_status( dfu_device_t *device, dfu_status_t *status );
  *  return the 0 if successful or < 0 on an error
  */
 
-int32_t dfu_clear_status( dfu_device_t *device );
+int32_t dfu_clear_status (dfu_device_t *device);
 /*  DFU_CLRSTATUS Request (DFU Spec 1.0, Section 6.1.3)
  *
  *  device    - the dfu device to communicate with
@@ -135,7 +133,7 @@ int32_t dfu_clear_status( dfu_device_t *device );
  *  return 0 or < 0 on an error
  */
 
-int32_t dfu_get_state( dfu_device_t *device );
+int32_t dfu_get_state (dfu_device_t *device);
 /*  DFU_GETSTATE Request (DFU Spec 1.0, Section 6.1.5)
  *
  *  device    - the dfu device to communicate with
@@ -143,7 +141,7 @@ int32_t dfu_get_state( dfu_device_t *device );
  *  returns the state or < 0 on error
  */
 
-int32_t dfu_abort( dfu_device_t *device );
+int32_t dfu_abort (dfu_device_t *device);
 /*  DFU_ABORT Request (DFU Spec 1.0, Section 6.1.4)
  *
  *  device    - the dfu device to communicate with
@@ -151,15 +149,9 @@ int32_t dfu_abort( dfu_device_t *device );
  *  returns 0 or < 0 on an error
  */
 
-
-struct libusb_device
-                     *dfu_device_init( const uint32_t vendor,
-                                       const uint32_t product,
-                                       const uint32_t bus,
-                                       const uint32_t dev_addr,
-                                       dfu_device_t *device,
-                                       const bool initial_abort,
-                                       const bool honor_interfaceclass );
+struct libusb_device *dfu_device_init (const uint32_t vendor, const uint32_t product, const uint32_t bus,
+                                       const uint32_t dev_addr, dfu_device_t *device, const bool initial_abort,
+                                       const bool honor_interfaceclass);
 /*  dfu_device_init is designed to find one of the usb devices which match
  *  the vendor and product parameters passed in.
  *
@@ -170,7 +162,7 @@ struct libusb_device
  *  return a pointer to the usb_device if found, or NULL otherwise
  */
 
-char* dfu_status_to_string( const int32_t status );
+char *dfu_status_to_string (const int32_t status);
 /*  Used to convert the DFU status to a string.
  *
  *  status - the status to convert
@@ -178,7 +170,7 @@ char* dfu_status_to_string( const int32_t status );
  *  returns the status name or "unknown status"
  */
 
-char* dfu_state_to_string( const int32_t state );
+char *dfu_state_to_string (const int32_t state);
 /*  Used to convert the DFU state to a string.
  *
  *  state - the state to convert

--- a/src/intel_hex.c
+++ b/src/intel_hex.c
@@ -31,8 +31,8 @@
  */
 
 #define _GNU_SOURCE
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -40,136 +40,127 @@
 #include "util.h"
 
 struct intel_record {
-    uint8_t count;      // single byte count
-    uint8_t type;       // single byte type
-    uint16_t address;   // two byte address
-    uint8_t checksum;   // single byte checksum
+    uint8_t count;    // single byte count
+    uint8_t type;     // single byte type
+    uint16_t address; // two byte address
+    uint8_t checksum; // single byte checksum
     uint8_t data[256];
 };
 
-#define IHEX_COLS 16
+#define IHEX_COLS      16
 #define IHEX_64KB_PAGE 0x10000
 
+#define IHEX_DEBUG_THRESHOLD 50
+#define IHEX_TRACE_THRESHOLD 55
 
-#define IHEX_DEBUG_THRESHOLD    50
-#define IHEX_TRACE_THRESHOLD    55
-
-#define DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
-                               IHEX_DEBUG_THRESHOLD, __VA_ARGS__ )
-#define TRACE(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, \
-                               IHEX_TRACE_THRESHOLD, __VA_ARGS__ )
+#define DEBUG(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, IHEX_DEBUG_THRESHOLD, __VA_ARGS__)
+#define TRACE(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, IHEX_TRACE_THRESHOLD, __VA_ARGS__)
 
 // ________  P R O T O T Y P E S  _______________________________
-static int intel_validate_checksum( struct intel_record *record );
+static int intel_validate_checksum (struct intel_record *record);
 /*  This walks over the record and ensures that the checksum is
  *  correct for the record.
  *
  *  returns 0 if checksum validates, anything else on error
  */
 
-static int32_t ihex_make_line( struct intel_record *record, char *str );
+static int32_t ihex_make_line (struct intel_record *record, char *str);
 /* provide record type a list of values, they are converted into a line and put at str
  * values are 2 address bytes, the record type and any values. A checksum
  * is added to the end and the line length is prepended.
  */
 
-static int32_t ihex_make_checksum( struct intel_record *record );
+static int32_t ihex_make_checksum (struct intel_record *record);
 /* make a checksum using the values in record, place it in the record and
  * return 0
  */
 
-static int32_t ihex_make_record_04_offset( uint32_t offset, char *str );
+static int32_t ihex_make_record_04_offset (uint32_t offset, char *str);
 /* make an 04 record type offset, where the desired offset address is found by
  * multiplying value by 0x1000 (or the 64kb page size).  Therefore, the given
  * offset value must be a clean multiple of 0x10000.  the offset value
  * is placed in the buffer at str
  */
 
-//static int32_t ihex_process_record( struct intel_record *record,
-//        const uint8_t job, uint32_t next_address );
+// static int32_t ihex_process_record( struct intel_record *record,
+//         const uint8_t job, uint32_t next_address );
 /* call this function when a record needs to be processed (specify w/ job)
  * and a new blank record needs to be created
  */
 
-static void ihex_clear_record( struct intel_record *record, uint32_t address );
+static void ihex_clear_record (struct intel_record *record, uint32_t address);
 /* wipes out a record (resets it to zero)
  */
 
-
 // ________  F U N C T I O N S  _______________________________
-static int intel_validate_checksum( struct intel_record *record ) {
+static int
+intel_validate_checksum (struct intel_record *record) {
     int i = 0;
     int checksum = 0;
 
-    checksum = record->count + record->type + record->checksum +
-                        (record->address >> 8) + (0xff & record->address);
+    checksum = record->count + record->type + record->checksum + (record->address >> 8) + (0xff & record->address);
 
-    for( i = 0; i < record->count; i++ ) {
-        checksum += record->data[i];
-    }
+    for (i = 0; i < record->count; i++) { checksum += record->data[i]; }
 
     return (0xff & checksum);
 }
 
-static int intel_validate_line( struct intel_record *record ) {
+static int
+intel_validate_line (struct intel_record *record) {
     /* Validate the checksum */
-    if( 0 != intel_validate_checksum(record) ) {
-        DEBUG( "Checksum error.\n" );
+    if (0 != intel_validate_checksum (record)) {
+        DEBUG ("Checksum error.\n");
         return -1;
     }
 
     /* Validate the type */
-    switch( record->type ) {
-        /* Intel 1 format, for up to 64K length (types 0, 1) */
-        case 0:                             /* data record */
-            /* Nothing to do. */
-            break;
+    switch (record->type) {
+    /* Intel 1 format, for up to 64K length (types 0, 1) */
+    case 0: /* data record */
+        /* Nothing to do. */
+        break;
 
-        case 1:                             /* EOF record */
-            if( 0 != record->count ) {
-                DEBUG( "EOF record error.\n" );
-                return -2;
-            }
-            break;
+    case 1: /* EOF record */
+        if (0 != record->count) {
+            DEBUG ("EOF record error.\n");
+            return -2;
+        }
+        break;
 
-        /* Intel 2 format, when 20 bit addresses are needed (types 2, 3, 4) */
-        case 2:                             /* extended address record */
-            if(    (0 != record->address)
-                || (2 != record->count)
-                || (record->data[1] != (0xf8 & record->data[1])) )
-            {
-                DEBUG( "Intel2 Format Error.\n" );
-                return -3;
-            }
-            break;
+    /* Intel 2 format, when 20 bit addresses are needed (types 2, 3, 4) */
+    case 2: /* extended address record */
+        if ((0 != record->address) || (2 != record->count) || (record->data[1] != (0xf8 & record->data[1]))) {
+            DEBUG ("Intel2 Format Error.\n");
+            return -3;
+        }
+        break;
 
-        case 3:                             /* start address record */
-            /* just ignore these records (could verify addr == 0) */
-            break;
+    case 3: /* start address record */
+        /* just ignore these records (could verify addr == 0) */
+        break;
 
-        case 4:                             /* extended linear address record */
-            if( (0 != record->address) || (2 != record->count) ) {
-                DEBUG( "Extended Linear Address Record Format Error" );
-                return -4;
-            }
-            break;
+    case 4: /* extended linear address record */
+        if ((0 != record->address) || (2 != record->count)) {
+            DEBUG ("Extended Linear Address Record Format Error");
+            return -4;
+        }
+        break;
 
-        case 5:                             /* start linear address record */
-            if( (0 != record->address) || (4 != record->count) ) {
-                return -6;
-            }
-            break;
+    case 5: /* start linear address record */
+        if ((0 != record->address) || (4 != record->count)) { return -6; }
+        break;
 
-        default:
-            fprintf( stderr, "Unsupported type. %d\n", record->type );
-            /* Type 5 and other types are unsupported. */
-            return -5;
+    default:
+        fprintf (stderr, "Unsupported type. %d\n", record->type);
+        /* Type 5 and other types are unsupported. */
+        return -5;
     }
 
     return 0;
 }
 
-static int intel_read_data( FILE *fp, struct intel_record *record ) {
+static int
+intel_read_data (FILE *fp, struct intel_record *record) {
     int i;
     int c;
     int status;
@@ -188,59 +179,53 @@ static int intel_read_data( FILE *fp, struct intel_record *record ) {
      *   rr - record type
      */
 
-    if( NULL == fgets(buffer, 10, fp) )                     return -1;
-    status = sscanf( buffer, ":%02x%02x%02x%02x", &count,
-                     &addr_upper, &addr_lower, &type );
-    if( 4 != status )                                       return -2;
+    if (NULL == fgets (buffer, 10, fp)) return -1;
+    status = sscanf (buffer, ":%02x%02x%02x%02x", &count, &addr_upper, &addr_lower, &type);
+    if (4 != status) return -2;
 
-    record->count =   (uint8_t)  count;
-    record->address = (uint16_t) (addr_upper << 8 | addr_lower);
-    record->type =    (uint8_t)  type;
+    record->count = (uint8_t)count;
+    record->address = (uint16_t)(addr_upper << 8 | addr_lower);
+    record->type = (uint8_t)type;
 
     /* Read the data */
-    for( i = 0; i < record->count; i++ ) {
-        if( NULL == fgets(buffer, 3, fp) )                  return -3;
-        if( 1 != sscanf(buffer, "%02x", &data) )            return -4;
+    for (i = 0; i < record->count; i++) {
+        if (NULL == fgets (buffer, 3, fp)) return -3;
+        if (1 != sscanf (buffer, "%02x", &data)) return -4;
 
-        record->data[i] = (uint8_t) (0xff & data);
+        record->data[i] = (uint8_t)(0xff & data);
     }
 
     /* Read the checksum */
-    if( NULL == fgets(buffer, 3, fp) )                      return -5;
-    if( 1 != sscanf(buffer, "%02x", &checksum) )            return -6;
+    if (NULL == fgets (buffer, 3, fp)) return -5;
+    if (1 != sscanf (buffer, "%02x", &checksum)) return -6;
 
     /* Chomp the [\r]\n */
-    c = fgetc( fp );
-    if( '\r' == c ) {
-        c = fgetc( fp );
+    c = fgetc (fp);
+    if ('\r' == c) { c = fgetc (fp); }
+    if ('\n' != c) {
+        DEBUG ("Error: end of line != \\n.\n");
+        return -7;
     }
-    if( '\n' != c ) {
-        DEBUG( "Error: end of line != \\n.\n" );            return -7;
-    }
-    record->checksum = (uint8_t) checksum;
+    record->checksum = (uint8_t)checksum;
 
     return 0;
 }
 
-static void intel_invalid_addr_warning(uint32_t line_count, uint32_t address,
-        uint32_t target_offset, size_t total_size) {
-    DEBUG("Valid address region from 0x%X to 0x%X.\n",
-        target_offset, target_offset + total_size - 1);
-    fprintf( stderr,
-        "WARNING (line %u): 0x%02x address outside valid region,\n",
-        line_count, address);
-    fprintf( stderr,
-            " suppressing additional address error messages.\n" );
+static void
+intel_invalid_addr_warning (uint32_t line_count, uint32_t address, uint32_t target_offset, size_t total_size) {
+    DEBUG ("Valid address region from 0x%X to 0x%X.\n", target_offset, target_offset + total_size - 1);
+    fprintf (stderr, "WARNING (line %u): 0x%02x address outside valid region,\n", line_count, address);
+    fprintf (stderr, " suppressing additional address error messages.\n");
 }
 
-int32_t intel_process_data( intel_buffer_out_t *bout, char value,
-        uint32_t target_offset, uint32_t address) {
+int32_t
+intel_process_data (intel_buffer_out_t *bout, char value, uint32_t target_offset, uint32_t address) {
     /* NOTE : there are some hex program files that contain data in the user
      * page, which is outside of 'valid' memory.  In this situation, the hex
      * file is processed and used as normal with a warning message containing
      * the first line with an invalid address.
      */
-    uint32_t raddress;   // relative address = address - target offset
+    uint32_t raddress; // relative address = address - target offset
     // cSpell:ignore raddress
 
     // The Atmel flash page starts at address 0x8000 0000, we need to ignore
@@ -249,57 +234,51 @@ int32_t intel_process_data( intel_buffer_out_t *bout, char value,
     target_offset &= 0x7fffffff;
     address &= 0x7fffffff;
 
-    if( (address < target_offset) ||
-        (address > target_offset + bout->info.total_size - 1) ) {
-        DEBUG( "Address 0x%X is outside valid range 0x%X to 0x%X.\n",
-                address, target_offset,
-                target_offset + bout->info.total_size - 1 );
+    if ((address < target_offset) || (address > target_offset + bout->info.total_size - 1)) {
+        DEBUG ("Address 0x%X is outside valid range 0x%X to 0x%X.\n", address, target_offset,
+               target_offset + bout->info.total_size - 1);
         return -1;
     } else {
         raddress = address - target_offset;
         // address >= target_offset so unsigned '-' is OK
-        bout->data[raddress] = (uint16_t) (0xff & value);
+        bout->data[raddress] = (uint16_t)(0xff & value);
         // update data limits
-        if( raddress < bout->info.data_start ) {
-            bout->info.data_start = raddress;
-        }
-        if( raddress > bout->info.data_end ) {
-            bout->info.data_end = raddress;
-        }
+        if (raddress < bout->info.data_start) { bout->info.data_start = raddress; }
+        if (raddress > bout->info.data_end) { bout->info.data_end = raddress; }
     }
     return 0;
 }
 
-int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
-                             uint32_t target_offset, bool quiet ) {
+int32_t
+intel_hex_to_buffer (char *filename, intel_buffer_out_t *bout, uint32_t target_offset, bool quiet) {
     FILE *fp = NULL;
     struct intel_record record;
     // unsigned int count, type, checksum, address; char data[256]
-    uint32_t address = 0;       // line address for intel_hex
-    uint32_t address_offset = 0;// offset address from intel_hex
-    uint32_t line_count = 1;                // used for debugging hex file
-    int32_t  invalid_address_count = 0;     // used for error checking
-    int32_t retval;             // return value
+    uint32_t address = 0;              // line address for intel_hex
+    uint32_t address_offset = 0;       // offset address from intel_hex
+    uint32_t line_count = 1;           // used for debugging hex file
+    int32_t invalid_address_count = 0; // used for error checking
+    int32_t retval;                    // return value
     int i = 0;
 
-    if ( (0 >= bout->info.total_size) ) {
-        DEBUG( "Must provide valid memory size in bout.\n" );
+    if ((0 >= bout->info.total_size)) {
+        DEBUG ("Must provide valid memory size in bout.\n");
         retval = -1;
         goto error;
     }
 
     if (NULL == filename) {
-        if( !quiet ) fprintf( stderr, "Invalid filename.\n" );
+        if (!quiet) fprintf (stderr, "Invalid filename.\n");
         retval = -2;
         goto error;
     }
 
-    if( 0 == strcmp("STDIN", filename) ) {
+    if (0 == strcmp ("STDIN", filename)) {
         fp = stdin;
     } else {
-        fp = fopen( filename, "r" );
-        if( NULL == fp ) {
-            if( !quiet ) fprintf( stderr, "Error opening %s\n", filename );
+        fp = fopen (filename, "r");
+        if (NULL == fp) {
+            if (!quiet) fprintf (stderr, "Error opening %s\n", filename);
             retval = -3;
             goto error;
         }
@@ -308,176 +287,163 @@ int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
     // iterate through ihex file and assign values to memory and user
     do {
         // read the data
-        if( 0 != intel_read_data(fp, &record) ) {
-            if( !quiet )
-                fprintf( stderr, "Error reading line %u.\n", line_count );
+        if (0 != intel_read_data (fp, &record)) {
+            if (!quiet) fprintf (stderr, "Error reading line %u.\n", line_count);
             retval = -4;
             goto error;
-        } else if ( 0 != intel_validate_line( &record ) ) {
-            if( !quiet )
-                fprintf( stderr, "Error: Line %u does not validate.\n", line_count );
+        } else if (0 != intel_validate_line (&record)) {
+            if (!quiet) fprintf (stderr, "Error: Line %u does not validate.\n", line_count);
             retval = -5;
             goto error;
         } else
             line_count++;
 
         // process the data
-        switch( record.type ) {
-            case 0:
-                for( address = address_offset + ((uint32_t) record.address),
-                        i = 0; i < record.count; i++, address++ ) {
-                    if ( 0 != intel_process_data(bout, record.data[i],
-                                target_offset, address) ) {
-                        // address was invalid
-                        if ( !invalid_address_count ) {
-                            intel_invalid_addr_warning(line_count, address,
-                                    target_offset, bout->info.total_size );
-                        }
-                        invalid_address_count++;
+        switch (record.type) {
+        case 0:
+            for (address = address_offset + ((uint32_t)record.address), i = 0; i < record.count; i++, address++) {
+                if (0 != intel_process_data (bout, record.data[i], target_offset, address)) {
+                    // address was invalid
+                    if (!invalid_address_count) {
+                        intel_invalid_addr_warning (line_count, address, target_offset, bout->info.total_size);
                     }
+                    invalid_address_count++;
                 }
-                break;
-            case 2:             // 0x1238 -> 0x00012380
-                address_offset = (((uint32_t) record.data[0]) << 12) |
-                                  ((uint32_t) record.data[1]) << 4;
-                address_offset = (0x7fffffff & address_offset);
-                DEBUG( "Address offset set to 0x%x.\n", address_offset );
-                break;
-            case 4:             // 0x1234 -> 0x12340000
-                address_offset = (((uint32_t) record.data[0]) << 24) |
-                                  ((uint32_t) record.data[1]) << 16;
-                address_offset = (0x7fffffff & address_offset);
-                DEBUG( "Address offset set to 0x%x.\n", address_offset );
-                break;
-            case 5:             // 0x12345678 -> 0x12345678
-                address_offset = (((uint32_t) record.data[0]) << 24) |
-                                 (((uint32_t) record.data[1]) << 16) |
-                                 (((uint32_t) record.data[2]) <<  8) |
-                                  ((uint32_t) record.data[3]);
-                /* Note: In AVR32 memory map, FLASH starts at 0x80000000, but
-                 * the ISP places this memory at 0. The hex file will use
-                 * 0x8..., so mask off that bit. */
-                address_offset = (0x7fffffff & address_offset);
-                DEBUG( "Address offset set to 0x%x.\n", address_offset );
-                break;
+            }
+            break;
+        case 2: // 0x1238 -> 0x00012380
+            address_offset = (((uint32_t)record.data[0]) << 12) | ((uint32_t)record.data[1]) << 4;
+            address_offset = (0x7fffffff & address_offset);
+            DEBUG ("Address offset set to 0x%x.\n", address_offset);
+            break;
+        case 4: // 0x1234 -> 0x12340000
+            address_offset = (((uint32_t)record.data[0]) << 24) | ((uint32_t)record.data[1]) << 16;
+            address_offset = (0x7fffffff & address_offset);
+            DEBUG ("Address offset set to 0x%x.\n", address_offset);
+            break;
+        case 5: // 0x12345678 -> 0x12345678
+            address_offset = (((uint32_t)record.data[0]) << 24) | (((uint32_t)record.data[1]) << 16)
+                             | (((uint32_t)record.data[2]) << 8) | ((uint32_t)record.data[3]);
+            /* Note: In AVR32 memory map, FLASH starts at 0x80000000, but
+             * the ISP places this memory at 0. The hex file will use
+             * 0x8..., so mask off that bit. */
+            address_offset = (0x7fffffff & address_offset);
+            DEBUG ("Address offset set to 0x%x.\n", address_offset);
+            break;
         }
-    } while( (1 != record.type) );
+    } while ((1 != record.type));
 
-    if ( invalid_address_count ) {
-        if( !quiet )
-            fprintf( stderr, "Total of 0x%X bytes in invalid addressed.\n",
-                    invalid_address_count );
+    if (invalid_address_count) {
+        if (!quiet) fprintf (stderr, "Total of 0x%X bytes in invalid addressed.\n", invalid_address_count);
     }
 
     retval = invalid_address_count;
 
 error:
-    if( NULL != fp ) {
-        fclose( fp );
+    if (NULL != fp) {
+        fclose (fp);
         fp = NULL;
     }
 
-    if( retval & !quiet ) {
-        fprintf( stderr, "See --debug=%u or greater for more information.\n",
-                IHEX_DEBUG_THRESHOLD + 1 );
+    if (retval & !quiet) {
+        fprintf (stderr, "See --debug=%u or greater for more information.\n", IHEX_DEBUG_THRESHOLD + 1);
     }
 
     return retval;
 }
 
 // ___ CONVERT TO INTEL HEX __________________________
-static void ihex_clear_record( struct intel_record *record, uint32_t address ) {
+static void
+ihex_clear_record (struct intel_record *record, uint32_t address) {
     record->count = 0;
-    record->address = ((uint16_t) (address % 0xffff));
+    record->address = ((uint16_t)(address % 0xffff));
     record->type = 0;
     record->data[0] = 0;
     record->checksum = 0;
 }
 
-static int32_t ihex_make_checksum( struct intel_record *record ) {
+static int32_t
+ihex_make_checksum (struct intel_record *record) {
     uint16_t sum = 0;
     uint8_t i;
     sum += record->count;
     sum += record->type;
     sum += (record->address & 0xff) + (0xff & (record->address >> 8));
-    for( i = 0; i < record->count; i++ ) {
-        sum += record->data[i];
-    }
-    record->checksum = ((uint8_t) (0xff & (0x100 - (0xff & sum))));
+    for (i = 0; i < record->count; i++) { sum += record->data[i]; }
+    record->checksum = ((uint8_t)(0xff & (0x100 - (0xff & sum))));
     return 0;
 }
 
-static int32_t ihex_make_line( struct intel_record *record, char *str ) {
+static int32_t
+ihex_make_line (struct intel_record *record, char *str) {
     uint8_t i;
-    if( record->type > 5 ) {
-        DEBUG( "Record type 0x%X unknown.\n", record->type );
+    if (record->type > 5) {
+        DEBUG ("Record type 0x%X unknown.\n", record->type);
         return -1;
-    } else if( record->count > IHEX_COLS ) {
-        DEBUG( "Each line must have no more than 16 values.\n" );
+    } else if (record->count > IHEX_COLS) {
+        DEBUG ("Each line must have no more than 16 values.\n");
         return -1;
     }
 
-    if( record->count == 0 ) {
+    if (record->count == 0) {
         // if there is no data set the string to empty, return
         *str = 0;
         return 0;
     }
 
-    ihex_make_checksum(record);          // make the checksum
+    ihex_make_checksum (record); // make the checksum
 
-    sprintf( str, ":%02X%04X%02X",      // ':bbaaaarr'
-            record->count, record->address, record->type );
+    sprintf (str, ":%02X%04X%02X", // ':bbaaaarr'
+             record->count, record->address, record->type);
 
-    for ( i = 0; i < record->count; i++ ) {
-        sprintf( str + 9 + 2*i, "%02X", record->data[i] );
-    }
-    sprintf( str + 9 + 2*i, "%02X", record->checksum );
+    for (i = 0; i < record->count; i++) { sprintf (str + 9 + 2 * i, "%02X", record->data[i]); }
+    sprintf (str + 9 + 2 * i, "%02X", record->checksum);
 
     return 0;
 }
 
-static int32_t ihex_make_record_04_offset( uint32_t offset, char *str ) {
+static int32_t
+ihex_make_record_04_offset (uint32_t offset, char *str) {
     struct intel_record record;
-    if ( offset & 0xffff ) {
-        DEBUG( "ihex 04 type offset must be divisible by 0x%X, not 0x%X.\n",
-                0x10000, offset );
+    if (offset & 0xffff) {
+        DEBUG ("ihex 04 type offset must be divisible by 0x%X, not 0x%X.\n", 0x10000, offset);
         return -1;
     }
     record.type = 4;
     record.count = 2;
     record.address = 0;
-    record.data[0] = (uint8_t) (0xff & (offset >> 24));
-    record.data[1] = (uint8_t) (0xff & (offset >> 16));
-    return ihex_make_line( &record, str );
+    record.data[0] = (uint8_t)(0xff & (offset >> 24));
+    record.data[1] = (uint8_t)(0xff & (offset >> 16));
+    return ihex_make_line (&record, str);
 }
 
-//static int32_t ihex_process_record( struct intel_record *record,
-//        const uint8_t job, uint32_t next_address ) {
-//    char line[80];
-//    if( record->count ) {
-//        if( 0 != ihex_make_line(record, line) ) {
-//            DEBUG( "Error making a line.\n" );
-//            return -2;
-//        } else {
-//            ihex_clear_record( record, next_address );
-//        }
-//        if( job==0 ) {
-//            fprintf( stdout, "%s\n", line );
-//        }
-//    }
-//    return 0;
-//}
+// static int32_t ihex_process_record( struct intel_record *record,
+//         const uint8_t job, uint32_t next_address ) {
+//     char line[80];
+//     if( record->count ) {
+//         if( 0 != ihex_make_line(record, line) ) {
+//             DEBUG( "Error making a line.\n" );
+//             return -2;
+//         } else {
+//             ihex_clear_record( record, next_address );
+//         }
+//         if( job==0 ) {
+//             fprintf( stdout, "%s\n", line );
+//         }
+//     }
+//     return 0;
+// }
 
-int32_t intel_hex_from_buffer( intel_buffer_in_t *buin,
-                               bool force_full, uint32_t target_offset ) {
+int32_t
+intel_hex_from_buffer (intel_buffer_in_t *buin, bool force_full, uint32_t target_offset) {
     char line[80];
-    uint32_t offset_address = 0;    // offset address written to a previous line
-    uint32_t address = 0;   // relative offset from previously set addr
+    uint32_t offset_address = 0; // offset address written to a previous line
+    uint32_t address = 0;        // relative offset from previously set addr
     uint32_t i = buin->info.data_start;
     uint16_t i_scan;
     struct intel_record record;
 
-    ihex_clear_record( &record, i + target_offset );
+    ihex_clear_record (&record, i + target_offset);
 
     // target_offset = 0x8000 0000 or 0x8080 0000
     // use buin->info.data_start to buin->info.data_stop as range
@@ -485,114 +451,105 @@ int32_t intel_hex_from_buffer( intel_buffer_in_t *buin,
     // reasons to complete current line:
     //      last value, next page blank, last page value, #cols reached
 
-    for( i = buin->info.data_start; i <= buin->info.data_end; i++ ) {
+    for (i = buin->info.data_start; i <= buin->info.data_end; i++) {
         address = i + target_offset;
-        if( i % buin->info.page_size == 0 && !(force_full) ) {
+        if (i % buin->info.page_size == 0 && !(force_full)) {
             /* you are at the start of a memory page, if force_full is not set
              * then check if there is any data on the page, if there is none,
              * then write current line and increment to the next page
              */
-            for( i_scan = 0; i_scan < buin->info.page_size; i_scan++ ) {
-                if( buin->data[i + i_scan] != 0xFF )
-                    break;
+            for (i_scan = 0; i_scan < buin->info.page_size; i_scan++) {
+                if (buin->data[i + i_scan] != 0xFF) break;
             }
-            if( i_scan == buin->info.page_size ) {
+            if (i_scan == buin->info.page_size) {
                 // no data found: write current, jump to next page
-                if( 0 != ihex_make_line(&record, line) ) {
-                    DEBUG( "Error making a line.\n" );
+                if (0 != ihex_make_line (&record, line)) {
+                    DEBUG ("Error making a line.\n");
                     return -2;
                 } else {
-                    if( *line )
-                        fprintf( stdout, "%s\n", line );
-                    ihex_clear_record( &record, address + i_scan - offset_address );
+                    if (*line) fprintf (stdout, "%s\n", line);
+                    ihex_clear_record (&record, address + i_scan - offset_address);
                 }
                 i += buin->info.page_size - 1;
                 continue;
             }
         }
-        if( address - offset_address >= 0x10000 ) {
+        if (address - offset_address >= 0x10000) {
             offset_address = (address / IHEX_64KB_PAGE) * IHEX_64KB_PAGE;
             // complete the line, before adding this next point
 
-            if( 0 != ihex_make_line(&record, line) ) {
-                DEBUG( "Error making a line.\n" );
+            if (0 != ihex_make_line (&record, line)) {
+                DEBUG ("Error making a line.\n");
                 return -2;
             } else {
-                if( *line )
-                    fprintf( stdout, "%s\n", line );
-                ihex_clear_record( &record, address - offset_address );
+                if (*line) fprintf (stdout, "%s\n", line);
+                ihex_clear_record (&record, address - offset_address);
             }
 
             // reset offset address
-            if( 0 != ihex_make_record_04_offset(offset_address, line) ) {
-                DEBUG( "Error making a class 4 offset.\n" );
+            if (0 != ihex_make_record_04_offset (offset_address, line)) {
+                DEBUG ("Error making a class 4 offset.\n");
                 return -2;
             } else {
-                if( *line )
-                    fprintf( stdout, "%s\n", line );
+                if (*line) fprintf (stdout, "%s\n", line);
             }
         }
-        if( record.count == IHEX_COLS ) {
-            if( 0 != ihex_make_line(&record, line) ) {
-                DEBUG( "Error making a line.\n" );
+        if (record.count == IHEX_COLS) {
+            if (0 != ihex_make_line (&record, line)) {
+                DEBUG ("Error making a line.\n");
                 return -2;
             } else {
-                if( *line )
-                    fprintf( stdout, "%s\n", line );
-                ihex_clear_record( &record, address - offset_address );
+                if (*line) fprintf (stdout, "%s\n", line);
+                ihex_clear_record (&record, address - offset_address);
             }
         }
-        record.data[ record.count ] = buin->data[i];
-        record.count ++;
+        record.data[record.count] = buin->data[i];
+        record.count++;
     }
-    if( record.count ) {
-        if( 0 != ihex_make_line(&record, line) ) {
-            DEBUG( "Error making a line.\n" );
+    if (record.count) {
+        if (0 != ihex_make_line (&record, line)) {
+            DEBUG ("Error making a line.\n");
             return -2;
         } else {
-            if( *line )
-                fprintf( stdout, "%s\n", line );
-            ihex_clear_record( &record, address - offset_address );
+            if (*line) fprintf (stdout, "%s\n", line);
+            ihex_clear_record (&record, address - offset_address);
         }
     }
-    fprintf( stdout, ":00000001FF\n" );
+    fprintf (stdout, ":00000001FF\n");
 
     return 0;
 }
 
-int32_t intel_init_buffer_out( intel_buffer_out_t *bout,
-                               size_t total_size, size_t page_size ) {
+int32_t
+intel_init_buffer_out (intel_buffer_out_t *bout, size_t total_size, size_t page_size) {
     uint32_t i;
-    if ( !total_size || !page_size ) {
-        DEBUG("What are you thinking... size must be > 0.\n");
+    if (!total_size || !page_size) {
+        DEBUG ("What are you thinking... size must be > 0.\n");
         return -1;
     }
 
     bout->info.total_size = total_size;
     bout->info.page_size = page_size;
-    bout->info.data_start = UINT32_MAX;      // invalid data start
+    bout->info.data_start = UINT32_MAX; // invalid data start
     bout->info.data_end = 0;
     bout->info.valid_start = 0;
     bout->info.valid_end = total_size - 1;
     bout->info.block_start = 0;
     bout->info.block_end = 0;
     // allocate the memory
-    bout->data = (uint16_t *) malloc( total_size * sizeof(uint16_t) );
-    if( NULL == bout->data ) {
-        DEBUG( "ERROR allocating 0x%X bytes of memory.\n",
-                total_size * sizeof(uint16_t));
+    bout->data = (uint16_t *)malloc (total_size * sizeof (uint16_t));
+    if (NULL == bout->data) {
+        DEBUG ("ERROR allocating 0x%X bytes of memory.\n", total_size * sizeof (uint16_t));
         return -2;
     }
 
     // initialize buffer to 0xFFFF (invalid / unassigned data)
-    for( i = 0; i < total_size; i++ ) {
-        bout->data[i] = UINT16_MAX;
-    }
+    for (i = 0; i < total_size; i++) { bout->data[i] = UINT16_MAX; }
     return 0;
 }
 
-int32_t intel_init_buffer_in( intel_buffer_in_t *buin,
-                              size_t total_size, size_t page_size ) {
+int32_t
+intel_init_buffer_in (intel_buffer_in_t *buin, size_t total_size, size_t page_size) {
     // TODO : is there a way to combine this and above? maybe typecast to an
     // in or out buffer from a char pointer?
     buin->info.total_size = total_size;
@@ -604,92 +561,83 @@ int32_t intel_init_buffer_in( intel_buffer_in_t *buin,
     buin->info.block_start = 0;
     buin->info.block_end = 0;
 
-    buin->data = (uint8_t *) malloc( total_size );
-    if( NULL == buin->data ) {
-        DEBUG( "ERROR allocating 0x%X bytes of memory.\n", total_size );
+    buin->data = (uint8_t *)malloc (total_size);
+    if (NULL == buin->data) {
+        DEBUG ("ERROR allocating 0x%X bytes of memory.\n", total_size);
         return -2;
     }
 
     // initialize buffer to 0xFF (blank / unassigned data)
-    memset( buin->data, UINT8_MAX, total_size );
+    memset (buin->data, UINT8_MAX, total_size);
 
     return 0;
 }
 
-int32_t intel_validate_buffer( intel_buffer_in_t *buin,
-                               intel_buffer_out_t *bout,
-                               bool quiet) {
+int32_t
+intel_validate_buffer (intel_buffer_in_t *buin, intel_buffer_out_t *bout, bool quiet) {
     int32_t i;
     int32_t invalid_data_region = 0;
     int32_t invalid_outside_data_region = 0;
 
-    DEBUG( "Validating image from byte 0x%X to 0x%X.\n",
-            bout->info.valid_start, bout->info.valid_end );
+    DEBUG ("Validating image from byte 0x%X to 0x%X.\n", bout->info.valid_start, bout->info.valid_end);
 
-    if( !quiet ) fprintf( stderr, "Validating...  " );
-    for( i = bout->info.valid_start; i <= bout->info.valid_end; i++ ) {
-        if(  bout->data[i] <= UINT8_MAX ) {
+    if (!quiet) fprintf (stderr, "Validating...  ");
+    for (i = bout->info.valid_start; i <= bout->info.valid_end; i++) {
+        if (bout->data[i] <= UINT8_MAX) {
             // Memory should have been programmed here
-            if( ((uint8_t) bout->data[i]) != buin->data[i] ) {
-                if ( !invalid_data_region ) {
-                    if( !quiet ) fprintf( stderr, "ERROR\n" );
-                    DEBUG( "Image did not validate at byte: 0x%X of 0x%X.\n", i,
-                            bout->info.valid_end - bout->info.valid_start + 1 );
-                    DEBUG( "Wanted 0x%02x but read 0x%02x.\n",
-                            0xff & bout->data[i], buin->data[i] );
-                    DEBUG( "suppressing additional warnings.\n");
+            if (((uint8_t)bout->data[i]) != buin->data[i]) {
+                if (!invalid_data_region) {
+                    if (!quiet) fprintf (stderr, "ERROR\n");
+                    DEBUG ("Image did not validate at byte: 0x%X of 0x%X.\n", i,
+                           bout->info.valid_end - bout->info.valid_start + 1);
+                    DEBUG ("Wanted 0x%02x but read 0x%02x.\n", 0xff & bout->data[i], buin->data[i]);
+                    DEBUG ("suppressing additional warnings.\n");
                 }
                 invalid_data_region++;
             }
         } else {
             // Memory should be blank here
-            if( 0xff != buin->data[i] ) {
-                if ( !invalid_data_region ) {
-                    DEBUG( "Outside program region: byte 0x%X expected 0xFF.\n", i);
-                    DEBUG( "but read 0x%02X.  suppressing additional warnings.\n",
-                            buin->data[i] );
+            if (0xff != buin->data[i]) {
+                if (!invalid_data_region) {
+                    DEBUG ("Outside program region: byte 0x%X expected 0xFF.\n", i);
+                    DEBUG ("but read 0x%02X.  suppressing additional warnings.\n", buin->data[i]);
                 }
                 invalid_outside_data_region++;
             }
         }
     }
 
-    if( !quiet ) {
-        if ( 0 == invalid_data_region + invalid_outside_data_region ) {
-            fprintf( stderr, "Success\n" );
+    if (!quiet) {
+        if (0 == invalid_data_region + invalid_outside_data_region) {
+            fprintf (stderr, "Success\n");
         } else {
-            fprintf( stderr,
-                    "%d invalid bytes in program region, %d outside region.\n",
-                    invalid_data_region, invalid_outside_data_region );
+            fprintf (stderr, "%d invalid bytes in program region, %d outside region.\n", invalid_data_region,
+                     invalid_outside_data_region);
         }
     }
 
-    return invalid_data_region ?
-        -1 * invalid_data_region : invalid_outside_data_region;
+    return invalid_data_region ? -1 * invalid_data_region : invalid_outside_data_region;
 }
 
-int32_t intel_flash_prep_buffer( intel_buffer_out_t *bout ) {
+int32_t
+intel_flash_prep_buffer (intel_buffer_out_t *bout) {
     uint16_t *page;
     int32_t i;
 
-    TRACE( "%s( %p )\n", __FUNCTION__, bout );
+    TRACE ("%s( %p )\n", __FUNCTION__, bout);
 
     // increment pointer by page_size * sizeof(int16) until page_start >= end
-    for( page = bout->data;
-            page < &bout->data[bout->info.valid_end];
-            page = &page[bout->info.page_size] ) {
+    for (page = bout->data; page < &bout->data[bout->info.valid_end]; page = &page[bout->info.page_size]) {
         // check if there is valid data on this page
-        for( i = 0; i < bout->info.page_size; i++ ) {
-            if( page[i] <= UINT8_MAX )
-                break;
+        for (i = 0; i < bout->info.page_size; i++) {
+            if (page[i] <= UINT8_MAX) break;
         }
 
-        if( bout->info.page_size != i ) {
+        if (bout->info.page_size != i) {
             /* There was valid data in the block & we need to make
              * sure there is no unassigned data.  */
-            for( i = 0; i < bout->info.page_size; i++ ) {
-                if( page[i] > UINT8_MAX )
-                    page[i] = 0xff;         // 0xff is blank
+            for (i = 0; i < bout->info.page_size; i++) {
+                if (page[i] > UINT8_MAX) page[i] = 0xff; // 0xff is blank
             }
         }
     }

--- a/src/intel_hex.h
+++ b/src/intel_hex.h
@@ -21,18 +21,18 @@
 #ifndef __INTEL_HEX_H__
 #define __INTEL_HEX_H__
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct {
-    size_t total_size;          // the total size of the buffer
-    size_t  page_size;          // the size of a flash page
-    uint32_t block_start;       // the start addr of a transfer
-    uint32_t block_end;         // the end addr of a transfer
-    uint32_t data_start;        // the first valid data addr
-    uint32_t data_end;          // the last valid data addr
-    uint32_t valid_start;       // the first valid memory addr
-    uint32_t valid_end;         // the last valid memory addr
+    size_t total_size;    // the total size of the buffer
+    size_t page_size;     // the size of a flash page
+    uint32_t block_start; // the start addr of a transfer
+    uint32_t block_end;   // the end addr of a transfer
+    uint32_t data_start;  // the first valid data addr
+    uint32_t data_end;    // the last valid data addr
+    uint32_t valid_start; // the first valid memory addr
+    uint32_t valid_end;   // the last valid memory addr
 } intel_buffer_info_t;
 
 typedef struct {
@@ -45,9 +45,7 @@ typedef struct {
     uint8_t *data;
 } intel_buffer_in_t;
 
-
-int32_t intel_process_data( intel_buffer_out_t *bout,
-        char value, uint32_t target_offset, uint32_t address);
+int32_t intel_process_data (intel_buffer_out_t *bout, char value, uint32_t target_offset, uint32_t address);
 /* process a data value by adding to the buffer at the appropriate address or if
  * the address is out of range do nothing and return -1. Also update the valid
  * range of data in bout
@@ -57,8 +55,7 @@ int32_t intel_process_data( intel_buffer_out_t *bout,
 // NOTE : intel_process_data should be moved to a different module dealing with
 // processing any data and putting it into a buffer
 
-int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
-        uint32_t target_offset, bool quiet );
+int32_t intel_hex_to_buffer (char *filename, intel_buffer_out_t *bout, uint32_t target_offset, bool quiet);
 /*  Used to read in a file in intel hex format and return a chunk of
  *  memory containing the memory image described in the file.
  *
@@ -86,15 +83,13 @@ int32_t intel_hex_to_buffer( char *filename, intel_buffer_out_t *bout,
  *              data_start field in intel_buffer_out_t
  */
 
-int32_t intel_hex_from_buffer( intel_buffer_in_t *buin,
-        bool force_full, uint32_t target_offset );
+int32_t intel_hex_from_buffer (intel_buffer_in_t *buin, bool force_full, uint32_t target_offset);
 /*  Used to convert a buffer to an intel hex formatted file.
  *  target offset is the address location of buffer 0
  *  force_full sets whether to keep writing entirely blank pages.
  */
 
-int32_t intel_init_buffer_out(intel_buffer_out_t *bout,
-        size_t total_size, size_t page_size );
+int32_t intel_init_buffer_out (intel_buffer_out_t *bout, size_t total_size, size_t page_size);
 /* initialize a buffer used to send data to flash memory
  * the total size and page size must be provided.
  * the data array is filled with 0xFFFF (an invalid memory
@@ -105,22 +100,20 @@ int32_t intel_init_buffer_out(intel_buffer_out_t *bout,
  * to be found multiple times.
  */
 
-int32_t intel_init_buffer_in(intel_buffer_in_t *buin,
-        size_t total_size, size_t page_size );
+int32_t intel_init_buffer_in (intel_buffer_in_t *buin, size_t total_size, size_t page_size);
 /* initialize a buffer_in, used for reading the contents of program
  * memory.  total memory size must be provided.  the data array is filled
  * with 0xFF, which is unprogrammed memory.
  */
 
-int32_t intel_validate_buffer(  intel_buffer_in_t *buin,
-                                intel_buffer_out_t *bout, bool quiet);
+int32_t intel_validate_buffer (intel_buffer_in_t *buin, intel_buffer_out_t *bout, bool quiet);
 /* compare the contents of buffer_in with buffer_out to check that a target
  * memory image matches with a memory read.
  * return 0 for full validation, positive number if data bytes outside region do
  * not validate, negative number if bytes inside region that do not validate
  */
 
-int32_t intel_flash_prep_buffer( intel_buffer_out_t *bout );
+int32_t intel_flash_prep_buffer (intel_buffer_out_t *bout);
 /* prepare the buffer so that valid data fills each page that contains data.
  * unassigned data in buffer is given a value of 0xff (blank memory)
  * the buffer pointer must align with the beginning of a flash page

--- a/src/main.c
+++ b/src/main.c
@@ -18,23 +18,22 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
+#include <libusb-1.0/libusb.h>
 #include <stdio.h>
 #include <string.h>
-#include <libusb-1.0/libusb.h>
 
+#include "arguments.h"
+#include "atmel.h"
+#include "commands.h"
 #include "config.h"
 #include "dfu-device.h"
 #include "dfu.h"
-#include "atmel.h"
-#include "arguments.h"
-#include "commands.h"
-
 
 int debug;
 libusb_context *usbContext;
 
-int main( int argc, char **argv )
-{
+int
+main (int argc, char **argv) {
     static const char *progname = PACKAGE;
     int retval = SUCCESS;
     int status;
@@ -42,11 +41,11 @@ int main( int argc, char **argv )
     struct programmer_arguments args;
     struct libusb_device *device = NULL;
 
-    memset( &args, 0, sizeof(args) );
-    memset( &dfu_device, 0, sizeof(dfu_device) );
+    memset (&args, 0, sizeof (args));
+    memset (&dfu_device, 0, sizeof (dfu_device));
 
-    status = parse_arguments(&args, argc, argv);
-    if( status < 0 ) {
+    status = parse_arguments (&args, argc, argv);
+    if (status < 0) {
         /* Exit with an error. */
         return ARGUMENT_ERROR;
     } else if (status > 0) {
@@ -54,59 +53,52 @@ int main( int argc, char **argv )
         return SUCCESS;
     }
 
-    if (libusb_init(&usbContext)) {
-        fprintf( stderr, "%s: can't init libusb.\n", progname );
+    if (libusb_init (&usbContext)) {
+        fprintf (stderr, "%s: can't init libusb.\n", progname);
         return DEVICE_ACCESS_ERROR;
     }
 
-    if( debug >= 200 ) {
-    #if LIBUSB_API_VERSION >= 0x01000106
-        libusb_set_option(usbContext, LIBUSB_OPTION_LOG_LEVEL, debug);
-    #else
-        libusb_set_debug(usbContext, debug );
-    #endif
+    if (debug >= 200) {
+#if LIBUSB_API_VERSION >= 0x01000106
+        libusb_set_option (usbContext, LIBUSB_OPTION_LOG_LEVEL, debug);
+#else
+        libusb_set_debug (usbContext, debug);
+#endif
     }
 
-    device = dfu_device_init( args.vendor_id, args.chip_id,
-                                args.bus_id, args.device_address,
-                                &dfu_device,
-                                args.initial_abort,
-                                args.honor_interfaceclass );
+    device = dfu_device_init (args.vendor_id, args.chip_id, args.bus_id, args.device_address, &dfu_device,
+                              args.initial_abort, args.honor_interfaceclass);
 
-    if( NULL == device ) {
-        fprintf( stderr, "%s: no device present.\n", progname );
+    if (NULL == device) {
+        fprintf (stderr, "%s: no device present.\n", progname);
         retval = DEVICE_ACCESS_ERROR;
         goto error;
     }
 
-    if( 0 != (retval = execute_command(&dfu_device, &args)) ) {
+    if (0 != (retval = execute_command (&dfu_device, &args))) {
         /* command issued a specific diagnostic already */
         goto error;
     }
 
 error:
-    if( NULL != dfu_device.handle ) {
+    if (NULL != dfu_device.handle) {
         int rv;
 
-        rv = libusb_release_interface( dfu_device.handle, dfu_device.interface );
+        rv = libusb_release_interface (dfu_device.handle, dfu_device.interface);
         /* The RESET command sometimes causes the usb_release_interface command to fail.
            It is not obvious why this happens but it may be a glitch due to the hardware
            reset in the attached device. In any event, since reset causes a USB detach
            this should not matter, so there is no point in raising an alarm.
         */
-        if( 0 != rv && !(com_launch == args.command &&
-                args.com_launch_config.noreset == 0) ) {
-            fprintf( stderr, "%s: failed to release interface %d.\n",
-                             progname, dfu_device.interface );
+        if (0 != rv && !(com_launch == args.command && args.com_launch_config.noreset == 0)) {
+            fprintf (stderr, "%s: failed to release interface %d.\n", progname, dfu_device.interface);
             retval = DEVICE_ACCESS_ERROR;
         }
     }
 
-    if( NULL != dfu_device.handle ) {
-        libusb_close(dfu_device.handle);
-    }
+    if (NULL != dfu_device.handle) { libusb_close (dfu_device.handle); }
 
-    libusb_exit(usbContext);
+    libusb_exit (usbContext);
 
     return retval;
 }

--- a/src/stm32.c
+++ b/src/stm32.c
@@ -1,752 +1,695 @@
 /** dfu-programmer
-  *
-  * This program is free software; you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation; either version 2 of the License, or
-  * (at your option) any later version.
-  *
-  * This program is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program; if not, write to the Free Software Foundation,
-  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
-  */
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
 
 //___ I N C L U D E S ________________________________________________________
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <string.h>
-#include <stddef.h>
 #include <errno.h>
+#include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
-#include "dfu-device.h"
-#include "config.h"
 #include "arguments.h"
+#include "config.h"
+#include "dfu-device.h"
 #include "dfu.h"
 #include "stm32.h"
 #include "util.h"
 
-
 //___ M A C R O S   ( P R I V A T E ) ________________________________________
-#define STM32_DEBUG_THRESHOLD   50
-#define STM32_TRACE_THRESHOLD   55
+#define STM32_DEBUG_THRESHOLD 50
+#define STM32_TRACE_THRESHOLD 55
 
-#define DEBUG(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, STM32_DEBUG_THRESHOLD, __VA_ARGS__ )
-#define TRACE(...)  dfu_debug( __FILE__, __FUNCTION__, __LINE__, STM32_TRACE_THRESHOLD, __VA_ARGS__ )
+#define DEBUG(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, STM32_DEBUG_THRESHOLD, __VA_ARGS__)
+#define TRACE(...) dfu_debug (__FILE__, __FUNCTION__, __LINE__, STM32_TRACE_THRESHOLD, __VA_ARGS__)
 
-#define STM32_MAX_TRANSFER_SIZE     0x0800  /* 2048 */
-#define STM32_MIN_SECTOR_BOUND      0x4000  /* 16 kb */
-#define STM32_OTP_BYTES_SIZE        528     /* number of OTP bytes (0x210) */
-#define STM32_OPTION_BYTES_SIZE     16      /* number option bytes */
+#define STM32_MAX_TRANSFER_SIZE 0x0800 /* 2048 */
+#define STM32_MIN_SECTOR_BOUND  0x4000 /* 16 kb */
+#define STM32_OTP_BYTES_SIZE    528    /* number of OTP bytes (0x210) */
+#define STM32_OPTION_BYTES_SIZE 16     /* number option bytes */
 
-#define SET_ADDR_PTR            0x21
-#define ERASE_CMD               0x41
-#define READ_UNPROTECT          0x92
-#define GET_CMD                 0x00
+#define SET_ADDR_PTR   0x21
+#define ERASE_CMD      0x41
+#define READ_UNPROTECT 0x92
+#define GET_CMD        0x00
 
 //___ T Y P E D E F S   ( P R I V A T E ) ____________________________________
 
 //___ P R O T O T Y P E S   ( P R I V A T E ) ________________________________
-static inline int32_t stm32_get_status( dfu_device_t *device );
-  /* run dfu_get_status to get the current status
-   * return 0 on status OK, -1 on status req fail, -2 on bad status
-   */
+static inline int32_t stm32_get_status (dfu_device_t *device);
+/* run dfu_get_status to get the current status
+ * return 0 on status OK, -1 on status req fail, -2 on bad status
+ */
 
-static int32_t stm32_set_address_ptr( dfu_device_t *device, uint32_t address );
-  /* @brief set the address pointer to a certain address
-   * @param the address to set
-   * @return 0 on success, negative on failure
-   */
+static int32_t stm32_set_address_ptr (dfu_device_t *device, uint32_t address);
+/* @brief set the address pointer to a certain address
+ * @param the address to set
+ * @return 0 on success, negative on failure
+ */
 
-static int32_t stm32_write_block( dfu_device_t *device,
-                                  size_t xfer_len,
-                                  uint8_t *buffer );
-  /* flash the contents of memory into a block of memory.  it is assumed that
-   * the appropriate page has already been selected.  start and end are the
-   * start and end addresses of the flash data.  returns 0 on success,
-   * positive dfu error code if one is obtained, or negative if communication
-   * with device fails.
-   */
+static int32_t stm32_write_block (dfu_device_t *device, size_t xfer_len, uint8_t *buffer);
+/* flash the contents of memory into a block of memory.  it is assumed that
+ * the appropriate page has already been selected.  start and end are the
+ * start and end addresses of the flash data.  returns 0 on success,
+ * positive dfu error code if one is obtained, or negative if communication
+ * with device fails.
+ */
 
-static int32_t stm32_read_block( dfu_device_t *device,
-                                   size_t xfer_len,
-                                   uint8_t *buffer );
-  /* read a block of memory, assumes address pointer is already set
-   */
+static int32_t stm32_read_block (dfu_device_t *device, size_t xfer_len, uint8_t *buffer);
+/* read a block of memory, assumes address pointer is already set
+ */
 
-static inline void print_progress( intel_buffer_info_t *info,
-                    uint32_t *progress );
-  /* calculate how many progress indicator steps to print and print them
-   * update progress value
-   */
+static inline void print_progress (intel_buffer_info_t *info, uint32_t *progress);
+/* calculate how many progress indicator steps to print and print them
+ * update progress value
+ */
 
-static int32_t stm32_erase( dfu_device_t *device, uint8_t *command,
-                            uint8_t command_length, bool quiet );
-  /* erase, erase page, and read unprotect all share this functionality
-   * although with different commands
-   */
-
+static int32_t stm32_erase (dfu_device_t *device, uint8_t *command, uint8_t command_length, bool quiet);
+/* erase, erase page, and read unprotect all share this functionality
+ * although with different commands
+ */
 
 //___ V A R I A B L E S ______________________________________________________
-extern int debug;       /* defined in main.c */
+extern int debug; /* defined in main.c */
 
 /* FIXME : these should be read from usb device descriptor because they are
  * device specific */
 static const uint32_t stm32_sector_addresses[] = {
-  0x08000000,   /* sector  0,  16 kb */
-  0x08004000,   /* sector  1,  16 kb */
-  0x08008000,   /* sector  2,  16 kb */
-  0x0800C000,   /* sector  3,  16 kb */
-  0x08010000,   /* sector  4,  64 kb */
-  0x08020000,   /* sector  5, 128 kb */
-  0x08040000,   /* sector  6, 128 kb */
-  0x08060000,   /* sector  7, 128 kb */
-  0x08080000,   /* sector  8, 128 kb */
-  0x080A0000,   /* sector  9, 128 kb */
-  0x080C0000,   /* sector 10, 128 kb */
-  0x080E0000,   /* sector 11, 128 kb */
-  0x1FFF0000,   /* system memory, 30 kb */
-  0x1FFF7800,   /* OTP area, 528 bytes */
-  0x1FFFC000,   /* Option bytes, 16 bytes */
+    0x08000000, /* sector  0,  16 kb */
+    0x08004000, /* sector  1,  16 kb */
+    0x08008000, /* sector  2,  16 kb */
+    0x0800C000, /* sector  3,  16 kb */
+    0x08010000, /* sector  4,  64 kb */
+    0x08020000, /* sector  5, 128 kb */
+    0x08040000, /* sector  6, 128 kb */
+    0x08060000, /* sector  7, 128 kb */
+    0x08080000, /* sector  8, 128 kb */
+    0x080A0000, /* sector  9, 128 kb */
+    0x080C0000, /* sector 10, 128 kb */
+    0x080E0000, /* sector 11, 128 kb */
+    0x1FFF0000, /* system memory, 30 kb */
+    0x1FFF7800, /* OTP area, 528 bytes */
+    0x1FFFC000, /* Option bytes, 16 bytes */
 };
 
 //___ F U N C T I O N S   ( P R I V A T E ) __________________________________
-static inline int32_t stm32_get_status( dfu_device_t *device ) {
-  dfu_status_t status;
-  if( 0 == dfu_get_status(device, &status) ) {
-    if( status.bStatus == DFU_STATUS_OK ) {
-      DEBUG( "Status OK\n" );
-    } else {
-      DEBUG( "Status %s not OK, use DFU_CLRSTATUS\n",
-          dfu_status_to_string(status.bStatus) );
-      dfu_clear_status( device );
-      return -2;
-    }
-  } else {
-    DEBUG( "DFU_GETSTATUS request failed\n" );
-    return -1;
-  }
-
-  return 0;
-}
-
-static int32_t stm32_set_address_ptr( dfu_device_t *device, uint32_t address ) {
-  TRACE( "%s( 0x%X )\n", __FUNCTION__, address );
-  const uint8_t length = 5;
-  int32_t status;
-
-  uint8_t command[] = {
-    (uint8_t) SET_ADDR_PTR,
-    (uint8_t) address & 0xFF,           /* address LSB */
-    (uint8_t) (address>>8) & 0xFF,
-    (uint8_t) (address>>16) & 0xFF,
-    (uint8_t) (address>>24) & 0xFF      /* address MSB */
-  };
-
-  /* check dfu status for okay to send */
-  if( (status = stm32_get_status(device)) ) {
-    DEBUG("Error %d getting status on start\n", status);
-    return -1;
-  }
-
-  dfu_set_transaction_num( device, 0 );     /* set wValue to zero */
-  if( length != dfu_download(device, length, command) ) {
-    DEBUG( "dfu_download failed\n" );
-    return -2;
-  }
-
-  /* call dfu get status to trigger command */
-  if( (status = stm32_get_status(device)) ) {
-    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
-    return -3;
-  }
-
-  /* check command success */
-  if( (status = stm32_get_status(device)) ) {
-    DEBUG("Error %d: %s unsuccessful\n", status, __FUNCTION__);
-    return -4;
-  }
-
-  return 0;
-}
-
-static int32_t stm32_write_block( dfu_device_t *device,
-                                  size_t xfer_len,
-                                  uint8_t *buffer ) {
-  TRACE( "%s( %p, %u, %p )\n", __FUNCTION__, device, xfer_len, buffer );
-  int32_t status;
-
-  /* check input args */
-  if( (NULL == device) || (NULL == buffer) ) {
-    DEBUG( "ERROR: Invalid arguments, device/buffer pointer is NULL.\n" );
-    return -1;
-  } else if ( xfer_len > STM32_MAX_TRANSFER_SIZE ) {
-    DEBUG( "ERROR: 0x%X byte message > MAX TRANSFER SIZE (0x%X).\n",
-        xfer_len, STM32_MAX_TRANSFER_SIZE );
-    return -1;
-  } else if ( xfer_len < 1 ) {
-    DEBUG( "ERROR: xfer_len is %u\n", xfer_len );
-    return -1;
-  }
-
-  if( xfer_len != dfu_download(device, xfer_len, buffer) ) {
-    DEBUG( "dfu_download failed\n" );
-    return -3;
-  }
-
-  /* call dfu get status to trigger command */
-  if( (status = stm32_get_status(device)) ) {
-    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
-    return -3;
-  }
-
-  /* check that the command was successfully executed */
-  if( (status = stm32_get_status(device)) ) {
-    DEBUG("Error %d: %s unsuccessful\n", status, __FUNCTION__);
-    return -4;
-  }
-
-  return 0;
-}
-
-static int32_t stm32_read_block( dfu_device_t *device,
-                                   size_t xfer_len,
-                                   uint8_t *buffer ) {
-  TRACE( "%s( %p, %u, %p )\n", __FUNCTION__, device, xfer_len, buffer );
-  int32_t result;
-
-  if( buffer == NULL ) {
-    DEBUG("ERROR: buffer ptr is NULL\n");
-    return -1;
-  } else if( xfer_len > STM32_MAX_TRANSFER_SIZE ) {
-    /* this could cause a read problem */
-    DEBUG("ERROR: transfer size %d exceeds max %d.\n",
-        xfer_len, STM32_MAX_TRANSFER_SIZE );
-    return -1;
-  }
-
-  /* check status before read */
-  if( (result = stm32_get_status(device)) ) {
-    DEBUG("Status Error %d before read\n", result );
-    return -2;
-  }
-
-  result = dfu_upload( device, xfer_len, buffer );
-  if( result < 0) {
+static inline int32_t
+stm32_get_status (dfu_device_t *device) {
     dfu_status_t status;
-
-    DEBUG( "ERROR: dfu_upload result: %d\n", result );
-    if( 0 == dfu_get_status(device, &status) ) {
-      DEBUG( "Error Status %s, state %s\n",
-          dfu_status_to_string(status.bStatus),
-          dfu_state_to_string(status.bState) );
-      if( status.bStatus == DFU_STATUS_ERROR_VENDOR ) {
-        /* status = dfuERROR and state = errVENDOR */
-        DEBUG("Device is read protected\n");
-        return STM32_READ_PROT_ERROR;
-      }
+    if (0 == dfu_get_status (device, &status)) {
+        if (status.bStatus == DFU_STATUS_OK) {
+            DEBUG ("Status OK\n");
+        } else {
+            DEBUG ("Status %s not OK, use DFU_CLRSTATUS\n", dfu_status_to_string (status.bStatus));
+            dfu_clear_status (device);
+            return -2;
+        }
     } else {
-      DEBUG("DFU GET_STATUS fail\n");
+        DEBUG ("DFU_GETSTATUS request failed\n");
+        return -1;
     }
-    dfu_clear_status( device );
 
-    return result;
-  }
-
-  return 0;
+    return 0;
 }
 
-static inline void print_progress( intel_buffer_info_t *info,
-                                     uint32_t *progress ) {
-  if ( !(debug > STM32_DEBUG_THRESHOLD) ) {
-    while ( ((info->block_end - info->data_start + 1) * 32) > *progress ) {
-      fprintf( stderr, ">" );
-      *progress += info->data_end - info->data_start + 1;
+static int32_t
+stm32_set_address_ptr (dfu_device_t *device, uint32_t address) {
+    TRACE ("%s( 0x%X )\n", __FUNCTION__, address);
+    const uint8_t length = 5;
+    int32_t status;
+
+    uint8_t command[] = {
+        (uint8_t)SET_ADDR_PTR, (uint8_t)address & 0xFF, /* address LSB */
+        (uint8_t)(address >> 8) & 0xFF, (uint8_t)(address >> 16) & 0xFF,
+        (uint8_t)(address >> 24) & 0xFF /* address MSB */
+    };
+
+    /* check dfu status for okay to send */
+    if ((status = stm32_get_status (device))) {
+        DEBUG ("Error %d getting status on start\n", status);
+        return -1;
     }
-  }
+
+    dfu_set_transaction_num (device, 0); /* set wValue to zero */
+    if (length != dfu_download (device, length, command)) {
+        DEBUG ("dfu_download failed\n");
+        return -2;
+    }
+
+    /* call dfu get status to trigger command */
+    if ((status = stm32_get_status (device))) {
+        DEBUG ("Error %d triggering %s\n", status, __FUNCTION__);
+        return -3;
+    }
+
+    /* check command success */
+    if ((status = stm32_get_status (device))) {
+        DEBUG ("Error %d: %s unsuccessful\n", status, __FUNCTION__);
+        return -4;
+    }
+
+    return 0;
 }
 
-static int32_t stm32_erase( dfu_device_t *device, uint8_t *command,
-                            uint8_t command_length, bool quiet ) {
-  int32_t status;
-  dfu_set_transaction_num( device, 0 );     /* set wValue to zero */
-  if( command_length != dfu_download(device, command_length, command) ) {
-    if( !quiet ) fprintf( stderr, "ERROR\n" );
-    DEBUG( "dfu_download failed\n" );
-    return UNSPECIFIED_ERROR;
-  }
+static int32_t
+stm32_write_block (dfu_device_t *device, size_t xfer_len, uint8_t *buffer) {
+    TRACE ("%s( %p, %u, %p )\n", __FUNCTION__, device, xfer_len, buffer);
+    int32_t status;
 
-  /* call dfu get status to trigger command */
-  if( (status = stm32_get_status(device)) ) {
-    if( !quiet ) fprintf( stderr, "ERROR\n" );
-    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
-    return UNSPECIFIED_ERROR;
-  }
+    /* check input args */
+    if ((NULL == device) || (NULL == buffer)) {
+        DEBUG ("ERROR: Invalid arguments, device/buffer pointer is NULL.\n");
+        return -1;
+    } else if (xfer_len > STM32_MAX_TRANSFER_SIZE) {
+        DEBUG ("ERROR: 0x%X byte message > MAX TRANSFER SIZE (0x%X).\n", xfer_len, STM32_MAX_TRANSFER_SIZE);
+        return -1;
+    } else if (xfer_len < 1) {
+        DEBUG ("ERROR: xfer_len is %u\n", xfer_len);
+        return -1;
+    }
 
-  /* check status again for erase status, this can take a while */
-  if( (status = stm32_get_status(device)) ) {
-    DEBUG("Error %d: %s unsuccessful\n", status, __FUNCTION__);
-    if( !quiet ) fprintf( stderr, "ERROR\n" );
-    return UNSPECIFIED_ERROR;
-  } else {
-    if( !quiet ) fprintf( stderr, "DONE\n" );
-  }
+    if (xfer_len != dfu_download (device, xfer_len, buffer)) {
+        DEBUG ("dfu_download failed\n");
+        return -3;
+    }
 
-  return SUCCESS;
+    /* call dfu get status to trigger command */
+    if ((status = stm32_get_status (device))) {
+        DEBUG ("Error %d triggering %s\n", status, __FUNCTION__);
+        return -3;
+    }
+
+    /* check that the command was successfully executed */
+    if ((status = stm32_get_status (device))) {
+        DEBUG ("Error %d: %s unsuccessful\n", status, __FUNCTION__);
+        return -4;
+    }
+
+    return 0;
+}
+
+static int32_t
+stm32_read_block (dfu_device_t *device, size_t xfer_len, uint8_t *buffer) {
+    TRACE ("%s( %p, %u, %p )\n", __FUNCTION__, device, xfer_len, buffer);
+    int32_t result;
+
+    if (buffer == NULL) {
+        DEBUG ("ERROR: buffer ptr is NULL\n");
+        return -1;
+    } else if (xfer_len > STM32_MAX_TRANSFER_SIZE) {
+        /* this could cause a read problem */
+        DEBUG ("ERROR: transfer size %d exceeds max %d.\n", xfer_len, STM32_MAX_TRANSFER_SIZE);
+        return -1;
+    }
+
+    /* check status before read */
+    if ((result = stm32_get_status (device))) {
+        DEBUG ("Status Error %d before read\n", result);
+        return -2;
+    }
+
+    result = dfu_upload (device, xfer_len, buffer);
+    if (result < 0) {
+        dfu_status_t status;
+
+        DEBUG ("ERROR: dfu_upload result: %d\n", result);
+        if (0 == dfu_get_status (device, &status)) {
+            DEBUG ("Error Status %s, state %s\n", dfu_status_to_string (status.bStatus),
+                   dfu_state_to_string (status.bState));
+            if (status.bStatus == DFU_STATUS_ERROR_VENDOR) {
+                /* status = dfuERROR and state = errVENDOR */
+                DEBUG ("Device is read protected\n");
+                return STM32_READ_PROT_ERROR;
+            }
+        } else {
+            DEBUG ("DFU GET_STATUS fail\n");
+        }
+        dfu_clear_status (device);
+
+        return result;
+    }
+
+    return 0;
+}
+
+static inline void
+print_progress (intel_buffer_info_t *info, uint32_t *progress) {
+    if (!(debug > STM32_DEBUG_THRESHOLD)) {
+        while (((info->block_end - info->data_start + 1) * 32) > *progress) {
+            fprintf (stderr, ">");
+            *progress += info->data_end - info->data_start + 1;
+        }
+    }
+}
+
+static int32_t
+stm32_erase (dfu_device_t *device, uint8_t *command, uint8_t command_length, bool quiet) {
+    int32_t status;
+    dfu_set_transaction_num (device, 0); /* set wValue to zero */
+    if (command_length != dfu_download (device, command_length, command)) {
+        if (!quiet) fprintf (stderr, "ERROR\n");
+        DEBUG ("dfu_download failed\n");
+        return UNSPECIFIED_ERROR;
+    }
+
+    /* call dfu get status to trigger command */
+    if ((status = stm32_get_status (device))) {
+        if (!quiet) fprintf (stderr, "ERROR\n");
+        DEBUG ("Error %d triggering %s\n", status, __FUNCTION__);
+        return UNSPECIFIED_ERROR;
+    }
+
+    /* check status again for erase status, this can take a while */
+    if ((status = stm32_get_status (device))) {
+        DEBUG ("Error %d: %s unsuccessful\n", status, __FUNCTION__);
+        if (!quiet) fprintf (stderr, "ERROR\n");
+        return UNSPECIFIED_ERROR;
+    } else {
+        if (!quiet) fprintf (stderr, "DONE\n");
+    }
+
+    return SUCCESS;
 }
 
 //___ F U N C T I O N S ______________________________________________________
-int32_t stm32_erase_flash( dfu_device_t *device, bool quiet ) {
-  TRACE( "%s( %p, %s )\n", __FUNCTION__, device, quiet ? "true" : "false" );
-  uint8_t command[] = { ERASE_CMD };
-  uint8_t length = 1;
+int32_t
+stm32_erase_flash (dfu_device_t *device, bool quiet) {
+    TRACE ("%s( %p, %s )\n", __FUNCTION__, device, quiet ? "true" : "false");
+    uint8_t command[] = { ERASE_CMD };
+    uint8_t length = 1;
 
-  if( !quiet ) {
-    fprintf( stderr, "Erasing flash...  " );
-    DEBUG("\n");
-  }
+    if (!quiet) {
+        fprintf (stderr, "Erasing flash...  ");
+        DEBUG ("\n");
+    }
 
-  return stm32_erase( device, command, length, quiet );
+    return stm32_erase (device, command, length, quiet);
 }
 
-int32_t stm32_page_erase( dfu_device_t *device, uint32_t address,
-                           bool quiet ) {
-  TRACE( "%s( %p, 0x%X, %s )\n", __FUNCTION__, device, address,
-      quiet ? "true" : "false" );
-  uint8_t length = 5;
+int32_t
+stm32_page_erase (dfu_device_t *device, uint32_t address, bool quiet) {
+    TRACE ("%s( %p, 0x%X, %s )\n", __FUNCTION__, device, address, quiet ? "true" : "false");
+    uint8_t length = 5;
 
-  uint8_t command[5] = {
-    ERASE_CMD,
-    (uint8_t) (0xff & address),             //  page LSB
-    (uint8_t) (0xff & ((address)>>8)),
-    (uint8_t) (0xff & ((address)>>16)),
-    (uint8_t) (0xff & ((address)>>24))      // page MSB
-  };
+    uint8_t command[5] = {
+        ERASE_CMD,
+        (uint8_t)(0xff & address), //  page LSB
+        (uint8_t)(0xff & ((address) >> 8)), (uint8_t)(0xff & ((address) >> 16)),
+        (uint8_t)(0xff & ((address) >> 24)) // page MSB
+    };
 
-  return stm32_erase( device, command, length, quiet );
+    return stm32_erase (device, command, length, quiet);
 }
 
-int32_t stm32_start_app( dfu_device_t *device, bool quiet ) {
-  TRACE( "%s( %p )\n", __FUNCTION__, device );
-  int32_t status;
+int32_t
+stm32_start_app (dfu_device_t *device, bool quiet) {
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
+    int32_t status;
 
-  /* set address pointer (jump target) to start address */
-  if( (status = stm32_set_address_ptr( device, STM32_FLASH_OFFSET )) ) {
-    DEBUG("Error setting address pointer\n");
-    return UNSPECIFIED_ERROR;
-  }
+    /* set address pointer (jump target) to start address */
+    if ((status = stm32_set_address_ptr (device, STM32_FLASH_OFFSET))) {
+        DEBUG ("Error setting address pointer\n");
+        return UNSPECIFIED_ERROR;
+    }
 
-  /* check dfu status for ok to send */
-  if( (status = stm32_get_status(device)) ) {
-    DEBUG("Error %d getting status on start\n", status);
-    return UNSPECIFIED_ERROR;
-  }
+    /* check dfu status for ok to send */
+    if ((status = stm32_get_status (device))) {
+        DEBUG ("Error %d getting status on start\n", status);
+        return UNSPECIFIED_ERROR;
+    }
 
-  if( !quiet ) fprintf( stderr, "Launching program...  \n" );
-  dfu_set_transaction_num( device, 0 );     /* set wValue to zero */
-  if( 0 != dfu_download(device, 0, NULL) ) {
-    if( !quiet ) fprintf( stderr, "ERROR\n" );
-    DEBUG( "dfu_download failed\n" );
-    return UNSPECIFIED_ERROR;
-  }
+    if (!quiet) fprintf (stderr, "Launching program...  \n");
+    dfu_set_transaction_num (device, 0); /* set wValue to zero */
+    if (0 != dfu_download (device, 0, NULL)) {
+        if (!quiet) fprintf (stderr, "ERROR\n");
+        DEBUG ("dfu_download failed\n");
+        return UNSPECIFIED_ERROR;
+    }
 
-  /* call dfu get status to trigger command */
-  if( (status = stm32_get_status(device)) ) {
-    DEBUG("Error %d triggering %s\n", status, __FUNCTION__);
-    return UNSPECIFIED_ERROR;
-  }
+    /* call dfu get status to trigger command */
+    if ((status = stm32_get_status (device))) {
+        DEBUG ("Error %d triggering %s\n", status, __FUNCTION__);
+        return UNSPECIFIED_ERROR;
+    }
 
-  return SUCCESS;
+    return SUCCESS;
 }
 
-int32_t stm32_read_flash( dfu_device_t *device, intel_buffer_in_t *buin,
-    const uint8_t mem_segment, const bool quiet ) {
-  TRACE( "%s( %p, %p, %u, %s )\n", __FUNCTION__, device, buin,
-      mem_segment, ((true == quiet) ? "true" : "false"));
+int32_t
+stm32_read_flash (dfu_device_t *device, intel_buffer_in_t *buin, const uint8_t mem_segment, const bool quiet) {
+    TRACE ("%s( %p, %p, %u, %s )\n", __FUNCTION__, device, buin, mem_segment, ((true == quiet) ? "true" : "false"));
 
-  uint8_t  reset_address_flag;  // reset address offset required
-  uint32_t address_offset;  // keep record of sent progress as bytes * 32
-  uint16_t  xfer_size = 0;      // the size of a transfer
-  uint8_t mem_section = 0;       // tracks the current memory page
-  uint32_t progress = 0;      // used to indicate progress
-  int32_t status;
-  int32_t retval = UNSPECIFIED_ERROR;   // the return value for this function
+    uint8_t reset_address_flag; // reset address offset required
+    uint32_t address_offset;    // keep record of sent progress as bytes * 32
+    uint16_t xfer_size = 0;     // the size of a transfer
+    uint8_t mem_section = 0;    // tracks the current memory page
+    uint32_t progress = 0;      // used to indicate progress
+    int32_t status;
+    int32_t retval = UNSPECIFIED_ERROR; // the return value for this function
 
-  if( (NULL == buin) || (NULL == device) ) {
-    DEBUG( "invalid arguments.\n" );
-    if( !quiet )
-      fprintf( stderr, "Program Error, use debug for more info.\n" );
-    return ARGUMENT_ERROR;
-  }
-
-  if( !quiet ) {
-    if( debug <= STM32_DEBUG_THRESHOLD ) {
-      /* NOTE: From here on we should go to finally on error */
-      fprintf( stderr, "[================================] " );
-    }
-    fprintf( stderr, "Reading 0x%X bytes...\n",
-        buin->info.data_end - buin->info.data_start + 1 );
-    if( debug <= STM32_DEBUG_THRESHOLD ) {
-      /* NOTE: From here on we should go to finally on error */
-      fprintf( stderr, "[" );
-    }
-  }
-
-  /* read the data */
-  buin->info.block_start = buin->info.data_start;
-  reset_address_flag = 0;
-  address_offset = buin->info.block_start;
-
-  while( buin->info.block_start <= buin->info.data_end ) {
-    if( reset_address_flag ) {
-      address_offset = buin->info.block_start;
-      if( (status = stm32_set_address_ptr(device,
-              STM32_FLASH_OFFSET + address_offset)) ) {
-        DEBUG("Error setting address 0x%X\n", address_offset);
-        retval = UNSPECIFIED_ERROR;
-        goto finally;
-      }
-      dfu_set_transaction_num( device, 2 ); /* sets block offset 0 */
-      reset_address_flag = 0;
+    if ((NULL == buin) || (NULL == device)) {
+        DEBUG ("invalid arguments.\n");
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
+        return ARGUMENT_ERROR;
     }
 
-    // find end value for the current transfer
-    buin->info.block_end = buin->info.block_start + STM32_MAX_TRANSFER_SIZE - 1;
-    mem_section = buin->info.block_start / STM32_MIN_SECTOR_BOUND;
-    if( buin->info.block_end / STM32_MIN_SECTOR_BOUND > mem_section ) {
-      buin->info.block_end = STM32_MIN_SECTOR_BOUND * mem_section - 1;
-    }
-    if( buin->info.block_end > buin->info.data_end ) {
-      buin->info.block_end = buin->info.data_end;
-    }
-    xfer_size = buin->info.block_end - buin->info.block_start + 1;
-    if( xfer_size != STM32_MAX_TRANSFER_SIZE ) {
-      DEBUG("xfer_size change, need addr reset\n");
-      reset_address_flag = 1;
+    if (!quiet) {
+        if (debug <= STM32_DEBUG_THRESHOLD) {
+            /* NOTE: From here on we should go to finally on error */
+            fprintf (stderr, "[================================] ");
+        }
+        fprintf (stderr, "Reading 0x%X bytes...\n", buin->info.data_end - buin->info.data_start + 1);
+        if (debug <= STM32_DEBUG_THRESHOLD) {
+            /* NOTE: From here on we should go to finally on error */
+            fprintf (stderr, "[");
+        }
     }
 
-    if( (status = stm32_read_block( device, xfer_size,
-            &buin->data[buin->info.block_start] )) ) {
-      DEBUG( "Error reading block 0x%X to 0x%X: err %d.\n",
-          buin->info.block_start, buin->info.block_end, status );
-      retval = ( status == -10 ) ? DEVICE_ACCESS_ERROR : FLASH_READ_ERROR;
-      /* read protect error code in read_block is -10 */
-      goto finally;
-    }
+    /* read the data */
+    buin->info.block_start = buin->info.data_start;
+    reset_address_flag = 0;
+    address_offset = buin->info.block_start;
 
-    buin->info.block_start = buin->info.block_end + 1;
-    if( reset_address_flag == 0 && (buin->info.block_start !=
-        (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num( device ) - 2))
-        + address_offset) ) {
-      DEBUG("block start & address mismatch, reset req\n");
-      reset_address_flag = 1;
-    }
+    while (buin->info.block_start <= buin->info.data_end) {
+        if (reset_address_flag) {
+            address_offset = buin->info.block_start;
+            if ((status = stm32_set_address_ptr (device, STM32_FLASH_OFFSET + address_offset))) {
+                DEBUG ("Error setting address 0x%X\n", address_offset);
+                retval = UNSPECIFIED_ERROR;
+                goto finally;
+            }
+            dfu_set_transaction_num (device, 2); /* sets block offset 0 */
+            reset_address_flag = 0;
+        }
 
-    if( !quiet ) print_progress( &buin->info, &progress );
-  }
-  retval = SUCCESS;
+        // find end value for the current transfer
+        buin->info.block_end = buin->info.block_start + STM32_MAX_TRANSFER_SIZE - 1;
+        mem_section = buin->info.block_start / STM32_MIN_SECTOR_BOUND;
+        if (buin->info.block_end / STM32_MIN_SECTOR_BOUND > mem_section) {
+            buin->info.block_end = STM32_MIN_SECTOR_BOUND * mem_section - 1;
+        }
+        if (buin->info.block_end > buin->info.data_end) { buin->info.block_end = buin->info.data_end; }
+        xfer_size = buin->info.block_end - buin->info.block_start + 1;
+        if (xfer_size != STM32_MAX_TRANSFER_SIZE) {
+            DEBUG ("xfer_size change, need addr reset\n");
+            reset_address_flag = 1;
+        }
+
+        if ((status = stm32_read_block (device, xfer_size, &buin->data[buin->info.block_start]))) {
+            DEBUG ("Error reading block 0x%X to 0x%X: err %d.\n", buin->info.block_start, buin->info.block_end, status);
+            retval = (status == -10) ? DEVICE_ACCESS_ERROR : FLASH_READ_ERROR;
+            /* read protect error code in read_block is -10 */
+            goto finally;
+        }
+
+        buin->info.block_start = buin->info.block_end + 1;
+        if (reset_address_flag == 0
+            && (buin->info.block_start
+                != (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num (device) - 2)) + address_offset)) {
+            DEBUG ("block start & address mismatch, reset req\n");
+            reset_address_flag = 1;
+        }
+
+        if (!quiet) print_progress (&buin->info, &progress);
+    }
+    retval = SUCCESS;
 
 finally:
-  if ( !quiet ) {
-    if( SUCCESS == retval ) {
-      if ( debug <= STM32_DEBUG_THRESHOLD ) {
-        fprintf( stderr, "] " );
-      }
-      fprintf( stderr, "SUCCESS\n" );
-    } else {
-      if ( debug <= STM32_DEBUG_THRESHOLD ) {
-        fprintf( stderr, " X  ");
-      }
-      fprintf( stderr, "ERROR\n" );
-      if( retval==DEVICE_ACCESS_ERROR )
-        fprintf( stderr,
-            "Memory access error, use debug for more info.\n" );
-      else if( retval==FLASH_READ_ERROR )
-        fprintf( stderr,
-            "Memory read error, use debug for more info.\n" );
+    if (!quiet) {
+        if (SUCCESS == retval) {
+            if (debug <= STM32_DEBUG_THRESHOLD) { fprintf (stderr, "] "); }
+            fprintf (stderr, "SUCCESS\n");
+        } else {
+            if (debug <= STM32_DEBUG_THRESHOLD) { fprintf (stderr, " X  "); }
+            fprintf (stderr, "ERROR\n");
+            if (retval == DEVICE_ACCESS_ERROR)
+                fprintf (stderr, "Memory access error, use debug for more info.\n");
+            else if (retval == FLASH_READ_ERROR)
+                fprintf (stderr, "Memory read error, use debug for more info.\n");
+        }
     }
-  }
-  return retval;
+    return retval;
 }
 
-int32_t stm32_write_flash( dfu_device_t *device, intel_buffer_out_t *bout,
-    const bool eeprom, const bool force, const bool quiet ) {
-  TRACE( "%s( %p, %p, %s, %s )\n", __FUNCTION__, device, bout,
-          ((true == eeprom) ? "true" : "false"),
-          ((true == quiet) ? "true" : "false") );
+int32_t
+stm32_write_flash (dfu_device_t *device, intel_buffer_out_t *bout, const bool eeprom, const bool force,
+                   const bool quiet) {
+    TRACE ("%s( %p, %p, %s, %s )\n", __FUNCTION__, device, bout, ((true == eeprom) ? "true" : "false"),
+           ((true == quiet) ? "true" : "false"));
 
-  uint32_t i;
-  uint32_t progress = 0;    // keep record of sent progress as bytes * 32
-  uint32_t address_offset;  // keep record of sent progress as bytes * 32
-  uint8_t  reset_address_flag;  // reset address offset required
-  uint16_t  xfer_size = 0;      // the size of a transfer
-  uint8_t mem_section = 0;   // tracks the current memory page
-  int32_t retval = UNSPECIFIED_ERROR;   // the return value for this function
-  uint8_t buffer[STM32_MAX_TRANSFER_SIZE];     // buffer holding out data
-  int32_t status;
+    uint32_t i;
+    uint32_t progress = 0;                   // keep record of sent progress as bytes * 32
+    uint32_t address_offset;                 // keep record of sent progress as bytes * 32
+    uint8_t reset_address_flag;              // reset address offset required
+    uint16_t xfer_size = 0;                  // the size of a transfer
+    uint8_t mem_section = 0;                 // tracks the current memory page
+    int32_t retval = UNSPECIFIED_ERROR;      // the return value for this function
+    uint8_t buffer[STM32_MAX_TRANSFER_SIZE]; // buffer holding out data
+    int32_t status;
 
-  /* check arguments */
-  if( (NULL == device) || (NULL == bout) ) {
-    DEBUG( "ERROR: Invalid arguments, device/buffer pointer is NULL.\n" );
-    if( !quiet )
-      fprintf( stderr, "Program Error, use debug for more info.\n" );
-    return ARGUMENT_ERROR;
-  } else if( bout->info.valid_start > bout->info.valid_end ) {
-    DEBUG( "ERROR: No valid target memory, end 0x%X before start 0x%X.\n",
-        bout->info.valid_end, bout->info.valid_start );
-    if( !quiet )
-      fprintf( stderr, "Program Error, use debug for more info.\n" );
-    return BUFFER_INIT_ERROR;
-  }
-
-  /* for each page with data, fill unassigned values on the page with 0xFF
-   * bout->data[0] always aligns with a flash page boundary irrespective
-   * of where valid_start is located */
-  if( 0 != intel_flash_prep_buffer( bout ) ) {
-    if( !quiet )
-      fprintf( stderr, "Program Error, use debug for more info.\n" );
-    return BUFFER_INIT_ERROR;
-  }
-
-  /* determine the limits of where actual data resides in the buffer */
-  bout->info.data_start = UINT32_MAX;
-  for( i = 0; i < bout->info.total_size; i++ ) {
-    if( bout->data[i] <= UINT8_MAX ) {
-      bout->info.data_end = i;
-      if( bout->info.data_start == UINT32_MAX )
-        bout->info.data_start = i;
-    }
-  }
-
-  /* debug info about data limits */
-  DEBUG("Flash available from 0x%X to 0x%X, 0x%X bytes.\n",
-      bout->info.valid_start, bout->info.valid_end,
-      bout->info.valid_end - bout->info.valid_start + 1); // bytes inclusive so +1
-  DEBUG("Data start @ 0x%X; %uB p 0x%X + 0x%X offset.\n",
-      bout->info.data_start, bout->info.page_size,
-      bout->info.data_start / bout->info.page_size,
-      bout->info.data_start % bout->info.page_size);
-  DEBUG("Data end @ 0x%X; %uB p 0x%X + 0x%X offset.\n",
-      bout->info.data_end, bout->info.page_size,
-      bout->info.data_end / bout->info.page_size,
-      bout->info.data_end % bout->info.page_size);
-  DEBUG("Totals: 0x%X bytes, %u %uB pages.\n",
-      bout->info.data_end - bout->info.data_start + 1,
-      bout->info.data_end / bout->info.page_size \
-        - bout->info.data_start/bout->info.page_size + 1,
-      bout->info.page_size );
-
-  /* more error checking */
-  if( (bout->info.data_start < bout->info.valid_start) ||
-      (bout->info.data_end > bout->info.valid_end) ) {
-    DEBUG( "ERROR: Data exists outside of the valid target flash region.\n" );
-    if( !quiet )
-      fprintf( stderr, "Hex file error, use debug for more info.\n" );
-    return BUFFER_INIT_ERROR;
-  } else if( bout->info.data_start == UINT32_MAX ) {
-    DEBUG( "ERROR: No valid data to flash.\n" );
-    if( !quiet )
-      fprintf( stderr, "Hex file error, use debug for more info.\n" );
-    return BUFFER_INIT_ERROR;
-  }
-
-  if( !quiet ) {
-    if( debug <= STM32_DEBUG_THRESHOLD ) {
-      /* NOTE: from here on we should run finally block */
-      fprintf( stderr, "[================================] " );
-    }
-    fprintf( stderr, "Programming 0x%X bytes...\n",
-        bout->info.data_end - bout->info.data_start + 1 );
-    if( debug <= STM32_DEBUG_THRESHOLD ) {
-      /* NOTE: from here on we need to run finally block */
-      fprintf( stderr, "[" );
-    }
-  }
-
-  /* program the data */
-  bout->info.block_start = bout->info.data_start;
-  reset_address_flag = 1;
-
-  while( bout->info.block_start <= bout->info.data_end ) {
-    if( reset_address_flag ) {
-      address_offset = bout->info.block_start;
-      if( (status = stm32_set_address_ptr(device,
-              STM32_FLASH_OFFSET + address_offset)) ) {
-        DEBUG("Error setting address 0x%X\n", address_offset);
-        retval = DEVICE_ACCESS_ERROR;
-        goto finally;
-      }
-      dfu_set_transaction_num( device, 2 ); /* sets block offset 0 */
-      reset_address_flag = 0;
+    /* check arguments */
+    if ((NULL == device) || (NULL == bout)) {
+        DEBUG ("ERROR: Invalid arguments, device/buffer pointer is NULL.\n");
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
+        return ARGUMENT_ERROR;
+    } else if (bout->info.valid_start > bout->info.valid_end) {
+        DEBUG ("ERROR: No valid target memory, end 0x%X before start 0x%X.\n", bout->info.valid_end,
+               bout->info.valid_start);
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
+        return BUFFER_INIT_ERROR;
     }
 
-    /* find end address (info.block_end) for data section to write */
-    mem_section = bout->info.block_start / STM32_MIN_SECTOR_BOUND;
-    for( i = 0, bout->info.block_end = bout->info.block_start;
-         bout->info.block_end <= bout->info.data_end;
-         bout->info.block_end++, i++ ) {
-      xfer_size = bout->info.block_end - bout->info.block_start + 1;
-      // check if the current value is valid
-      if( bout->data[bout->info.block_end] > UINT8_MAX ) break;
-      // check if the current data packet is too big
-      if( xfer_size > STM32_MAX_TRANSFER_SIZE ) break;
-      // check if the current data value is outside of the memory sector
-      if( bout->info.block_end / STM32_MIN_SECTOR_BOUND - mem_section ) break;
-
-      buffer[i] = (uint8_t) bout->data[bout->info.block_end];
-    }
-    bout->info.block_end--; // bout->info.block_end was one step beyond the last data value to flash
-    xfer_size = bout->info.block_end - bout->info.block_start + 1;
-    if( xfer_size != STM32_MAX_TRANSFER_SIZE ) {
-      DEBUG("xfer_size %u not max %u, need addr reset\n",
-          xfer_size, STM32_MAX_TRANSFER_SIZE);
-      reset_address_flag = 1;
+    /* for each page with data, fill unassigned values on the page with 0xFF
+     * bout->data[0] always aligns with a flash page boundary irrespective
+     * of where valid_start is located */
+    if (0 != intel_flash_prep_buffer (bout)) {
+        if (!quiet) fprintf (stderr, "Program Error, use debug for more info.\n");
+        return BUFFER_INIT_ERROR;
     }
 
-    /* write the data */
-    DEBUG("Program data block: 0x%X to 0x%X, 0x%X bytes.\n",
-        bout->info.block_start, bout->info.block_end, xfer_size);
-
-    if( (status = stm32_write_block( device, xfer_size, buffer )) ) {
-      DEBUG( "Error flashing the block: err %d.\n", status );
-      retval = FLASH_WRITE_ERROR;
-      goto finally;
+    /* determine the limits of where actual data resides in the buffer */
+    bout->info.data_start = UINT32_MAX;
+    for (i = 0; i < bout->info.total_size; i++) {
+        if (bout->data[i] <= UINT8_MAX) {
+            bout->info.data_end = i;
+            if (bout->info.data_start == UINT32_MAX) bout->info.data_start = i;
+        }
     }
 
-    // increment bout->info.block_start to the next valid address
-    for( bout->info.block_start = bout->info.block_end + 1;
-         bout->info.block_start <= bout->info.data_end;
-         bout->info.block_start++ ) {
-      if( (bout->data[bout->info.block_start] <= UINT8_MAX) ) break;
-    } // bout->info.block_start is now on the first valid data for the next segment
+    /* debug info about data limits */
+    DEBUG ("Flash available from 0x%X to 0x%X, 0x%X bytes.\n", bout->info.valid_start, bout->info.valid_end,
+           bout->info.valid_end - bout->info.valid_start + 1); // bytes inclusive so +1
+    DEBUG ("Data start @ 0x%X; %uB p 0x%X + 0x%X offset.\n", bout->info.data_start, bout->info.page_size,
+           bout->info.data_start / bout->info.page_size, bout->info.data_start % bout->info.page_size);
+    DEBUG ("Data end @ 0x%X; %uB p 0x%X + 0x%X offset.\n", bout->info.data_end, bout->info.page_size,
+           bout->info.data_end / bout->info.page_size, bout->info.data_end % bout->info.page_size);
+    DEBUG ("Totals: 0x%X bytes, %u %uB pages.\n", bout->info.data_end - bout->info.data_start + 1,
+           bout->info.data_end / bout->info.page_size - bout->info.data_start / bout->info.page_size + 1,
+           bout->info.page_size);
 
-    if( reset_address_flag == 0 && (bout->info.block_start !=
-        (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num( device ) - 2))
-        + address_offset) ) {
-      DEBUG("block start does not match addr, reset req\n");
-      reset_address_flag = 1;
+    /* more error checking */
+    if ((bout->info.data_start < bout->info.valid_start) || (bout->info.data_end > bout->info.valid_end)) {
+        DEBUG ("ERROR: Data exists outside of the valid target flash region.\n");
+        if (!quiet) fprintf (stderr, "Hex file error, use debug for more info.\n");
+        return BUFFER_INIT_ERROR;
+    } else if (bout->info.data_start == UINT32_MAX) {
+        DEBUG ("ERROR: No valid data to flash.\n");
+        if (!quiet) fprintf (stderr, "Hex file error, use debug for more info.\n");
+        return BUFFER_INIT_ERROR;
     }
 
-    // display progress in 32 increments (if not hidden)
-    if ( !quiet ) print_progress( &bout->info, &progress );
-  }
-  retval = SUCCESS;
+    if (!quiet) {
+        if (debug <= STM32_DEBUG_THRESHOLD) {
+            /* NOTE: from here on we should run finally block */
+            fprintf (stderr, "[================================] ");
+        }
+        fprintf (stderr, "Programming 0x%X bytes...\n", bout->info.data_end - bout->info.data_start + 1);
+        if (debug <= STM32_DEBUG_THRESHOLD) {
+            /* NOTE: from here on we need to run finally block */
+            fprintf (stderr, "[");
+        }
+    }
+
+    /* program the data */
+    bout->info.block_start = bout->info.data_start;
+    reset_address_flag = 1;
+
+    while (bout->info.block_start <= bout->info.data_end) {
+        if (reset_address_flag) {
+            address_offset = bout->info.block_start;
+            if ((status = stm32_set_address_ptr (device, STM32_FLASH_OFFSET + address_offset))) {
+                DEBUG ("Error setting address 0x%X\n", address_offset);
+                retval = DEVICE_ACCESS_ERROR;
+                goto finally;
+            }
+            dfu_set_transaction_num (device, 2); /* sets block offset 0 */
+            reset_address_flag = 0;
+        }
+
+        /* find end address (info.block_end) for data section to write */
+        mem_section = bout->info.block_start / STM32_MIN_SECTOR_BOUND;
+        for (i = 0, bout->info.block_end = bout->info.block_start; bout->info.block_end <= bout->info.data_end;
+             bout->info.block_end++, i++) {
+            xfer_size = bout->info.block_end - bout->info.block_start + 1;
+            // check if the current value is valid
+            if (bout->data[bout->info.block_end] > UINT8_MAX) break;
+            // check if the current data packet is too big
+            if (xfer_size > STM32_MAX_TRANSFER_SIZE) break;
+            // check if the current data value is outside of the memory sector
+            if (bout->info.block_end / STM32_MIN_SECTOR_BOUND - mem_section) break;
+
+            buffer[i] = (uint8_t)bout->data[bout->info.block_end];
+        }
+        bout->info.block_end--; // bout->info.block_end was one step beyond the last data value to flash
+        xfer_size = bout->info.block_end - bout->info.block_start + 1;
+        if (xfer_size != STM32_MAX_TRANSFER_SIZE) {
+            DEBUG ("xfer_size %u not max %u, need addr reset\n", xfer_size, STM32_MAX_TRANSFER_SIZE);
+            reset_address_flag = 1;
+        }
+
+        /* write the data */
+        DEBUG ("Program data block: 0x%X to 0x%X, 0x%X bytes.\n", bout->info.block_start, bout->info.block_end,
+               xfer_size);
+
+        if ((status = stm32_write_block (device, xfer_size, buffer))) {
+            DEBUG ("Error flashing the block: err %d.\n", status);
+            retval = FLASH_WRITE_ERROR;
+            goto finally;
+        }
+
+        // increment bout->info.block_start to the next valid address
+        for (bout->info.block_start = bout->info.block_end + 1; bout->info.block_start <= bout->info.data_end;
+             bout->info.block_start++) {
+            if ((bout->data[bout->info.block_start] <= UINT8_MAX)) break;
+        } // bout->info.block_start is now on the first valid data for the next segment
+
+        if (reset_address_flag == 0
+            && (bout->info.block_start
+                != (STM32_MAX_TRANSFER_SIZE * (dfu_get_transaction_num (device) - 2)) + address_offset)) {
+            DEBUG ("block start does not match addr, reset req\n");
+            reset_address_flag = 1;
+        }
+
+        // display progress in 32 increments (if not hidden)
+        if (!quiet) print_progress (&bout->info, &progress);
+    }
+    retval = SUCCESS;
 
 finally:
-  if ( !quiet ) {
-    if( SUCCESS == retval ) {
-      if ( debug <= STM32_DEBUG_THRESHOLD ) {
-        fprintf( stderr, "] " );
-      }
-      fprintf( stderr, "SUCCESS\n" );
-    } else {
-      if ( debug <= STM32_DEBUG_THRESHOLD ) {
-        fprintf( stderr, " X  ");
-      }
-      fprintf( stderr, "ERROR\n" );
-      if( retval==DEVICE_ACCESS_ERROR )
-        fprintf( stderr,
-            "Memory access error, use debug for more info.\n" );
-      else if( retval==FLASH_WRITE_ERROR )
-        fprintf( stderr,
-            "Memory write error, use debug for more info.\n" );
+    if (!quiet) {
+        if (SUCCESS == retval) {
+            if (debug <= STM32_DEBUG_THRESHOLD) { fprintf (stderr, "] "); }
+            fprintf (stderr, "SUCCESS\n");
+        } else {
+            if (debug <= STM32_DEBUG_THRESHOLD) { fprintf (stderr, " X  "); }
+            fprintf (stderr, "ERROR\n");
+            if (retval == DEVICE_ACCESS_ERROR)
+                fprintf (stderr, "Memory access error, use debug for more info.\n");
+            else if (retval == FLASH_WRITE_ERROR)
+                fprintf (stderr, "Memory write error, use debug for more info.\n");
+        }
     }
-  }
 
-  return retval;
+    return retval;
 }
 
-int32_t stm32_get_commands( dfu_device_t *device ) {
-  TRACE("%s( %p )\n", __FUNCTION__, device);
-  int32_t result;
-  uint8_t i;
-  const size_t xfer_len = 80;
-  uint8_t buffer[xfer_len];
+int32_t
+stm32_get_commands (dfu_device_t *device) {
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
+    int32_t result;
+    uint8_t i;
+    const size_t xfer_len = 80;
+    uint8_t buffer[xfer_len];
 
-  /* check status before read */
-  if( (result = stm32_get_status(device)) ) {
-    DEBUG("Status Error %d before read\n", result );
-    return UNSPECIFIED_ERROR;
-  }
-
-  dfu_set_transaction_num( device, 0 );
-  result = dfu_upload( device, xfer_len, buffer );
-  if( result < 0) {
-    dfu_status_t status;
-
-    DEBUG( "dfu_upload result: %d\n", result );
-    result = UNSPECIFIED_ERROR;
-    if( 0 == dfu_get_status(device, &status) ) {
-      if( status.bStatus == DFU_STATUS_OK ) {
-        DEBUG("DFU Status OK, state %d\n", status.bState);
-      } else if( status.bStatus == DFU_STATUS_ERROR_VENDOR ) {
-        DEBUG("Device is read protected\n");
-        /* status = dfuERROR and state = errVENDOR */
-        result = DEVICE_ACCESS_ERROR;
-      } else {
-        DEBUG("Unknown error status %d / state %d\n",
-            status.bStatus, status.bState );
-      }
-    } else {
-      DEBUG("DFU GET_STATUS fail\n");
+    /* check status before read */
+    if ((result = stm32_get_status (device))) {
+        DEBUG ("Status Error %d before read\n", result);
+        return UNSPECIFIED_ERROR;
     }
-    dfu_clear_status( device );
 
-    return result;
-  }
+    dfu_set_transaction_num (device, 0);
+    result = dfu_upload (device, xfer_len, buffer);
+    if (result < 0) {
+        dfu_status_t status;
 
-  fprintf( stdout, "There are %d commands:\n", result );
-  for( i = 0; i < result; i++ ) {
-    fprintf( stdout, "  0x%02X\n", buffer[i] );
-  }
+        DEBUG ("dfu_upload result: %d\n", result);
+        result = UNSPECIFIED_ERROR;
+        if (0 == dfu_get_status (device, &status)) {
+            if (status.bStatus == DFU_STATUS_OK) {
+                DEBUG ("DFU Status OK, state %d\n", status.bState);
+            } else if (status.bStatus == DFU_STATUS_ERROR_VENDOR) {
+                DEBUG ("Device is read protected\n");
+                /* status = dfuERROR and state = errVENDOR */
+                result = DEVICE_ACCESS_ERROR;
+            } else {
+                DEBUG ("Unknown error status %d / state %d\n", status.bStatus, status.bState);
+            }
+        } else {
+            DEBUG ("DFU GET_STATUS fail\n");
+        }
+        dfu_clear_status (device);
 
-  return SUCCESS;
+        return result;
+    }
+
+    fprintf (stdout, "There are %d commands:\n", result);
+    for (i = 0; i < result; i++) { fprintf (stdout, "  0x%02X\n", buffer[i]); }
+
+    return SUCCESS;
 }
 
-int32_t stm32_get_configuration( dfu_device_t *device ) {
-  TRACE("%s( %p )\n", __FUNCTION__, device);
-  int32_t status;
-  uint8_t i;
-  uint8_t buffer[STM32_OPTION_BYTES_SIZE];
+int32_t
+stm32_get_configuration (dfu_device_t *device) {
+    TRACE ("%s( %p )\n", __FUNCTION__, device);
+    int32_t status;
+    uint8_t i;
+    uint8_t buffer[STM32_OPTION_BYTES_SIZE];
 
-  if( (status = stm32_set_address_ptr(device,
-          stm32_sector_addresses[mem_st_option_bytes])) ) {
-    DEBUG("Error (%d) setting address 0x%X\n",
-        status, stm32_sector_addresses[mem_st_option_bytes]);
-    return UNSPECIFIED_ERROR;
-  }
+    if ((status = stm32_set_address_ptr (device, stm32_sector_addresses[mem_st_option_bytes]))) {
+        DEBUG ("Error (%d) setting address 0x%X\n", status, stm32_sector_addresses[mem_st_option_bytes]);
+        return UNSPECIFIED_ERROR;
+    }
 
-  if( (status = stm32_read_block(device, STM32_OPTION_BYTES_SIZE, buffer)) ) {
-    DEBUG("Error (%d) reading option buffer block\n", status );
-    return FLASH_READ_ERROR;
-  }
+    if ((status = stm32_read_block (device, STM32_OPTION_BYTES_SIZE, buffer))) {
+        DEBUG ("Error (%d) reading option buffer block\n", status);
+        return FLASH_READ_ERROR;
+    }
 
-  fprintf( stdout, "There are %d option bytes:\n", STM32_OPTION_BYTES_SIZE );
-  fprintf( stdout, "0x%02X", buffer[0] );
-  for( i = 1; i < STM32_OPTION_BYTES_SIZE; i++ ) {
-    fprintf( stdout, ", 0x%02X", buffer[i] );
-  }
-  fprintf( stdout, "\n" );
+    fprintf (stdout, "There are %d option bytes:\n", STM32_OPTION_BYTES_SIZE);
+    fprintf (stdout, "0x%02X", buffer[0]);
+    for (i = 1; i < STM32_OPTION_BYTES_SIZE; i++) { fprintf (stdout, ", 0x%02X", buffer[i]); }
+    fprintf (stdout, "\n");
 
-  return SUCCESS;
+    return SUCCESS;
 }
 
-int32_t stm32_read_unprotect( dfu_device_t *device, bool quiet ) {
-  TRACE( "%s( %p, %s )\n", __FUNCTION__, device, quiet ? "true" : "false" );
-  uint8_t command[] = { READ_UNPROTECT };
-  uint8_t length = 1;
+int32_t
+stm32_read_unprotect (dfu_device_t *device, bool quiet) {
+    TRACE ("%s( %p, %s )\n", __FUNCTION__, device, quiet ? "true" : "false");
+    uint8_t command[] = { READ_UNPROTECT };
+    uint8_t length = 1;
 
-  if( !quiet ) {
-    fprintf( stderr, "Read Unprotect, Erasing flash...  " );
-    DEBUG("\n");
-  }
+    if (!quiet) {
+        fprintf (stderr, "Read Unprotect, Erasing flash...  ");
+        DEBUG ("\n");
+    }
 
-  return stm32_erase( device, command, length, quiet );
+    return stm32_erase (device, command, length, quiet);
 }
 
 // cSpell:ignore shiftwidth

--- a/src/stm32.h
+++ b/src/stm32.h
@@ -1,26 +1,26 @@
 /** dfu-programmer
-  *
-  * This program is free software; you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation; either version 2 of the License, or
-  * (at your option) any later version.
-  *
-  * This program is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program; if not, write to the Free Software
-  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
-  */
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
 
 #ifndef __STM32_H__
 #define __STM32_H__
 
-#include <stdio.h>
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
 
 #include "dfu-device.h"
 #include "intel_hex.h"
@@ -28,86 +28,78 @@
 #define STM32_FLASH_OFFSET 0x08000000
 
 typedef enum {
-  mem_st_sector0 = 0,
-  mem_st_sector1,
-  mem_st_sector2,
-  mem_st_sector3,
-  mem_st_sector4,
-  mem_st_sector5,
-  mem_st_sector6,
-  mem_st_sector7,
-  mem_st_sector8,
-  mem_st_sector9,
-  mem_st_sector10,
-  mem_st_sector11,
-  mem_st_system,
-  mem_st_otp_area,
-  mem_st_option_bytes,
-  mem_st_all,
+    mem_st_sector0 = 0,
+    mem_st_sector1,
+    mem_st_sector2,
+    mem_st_sector3,
+    mem_st_sector4,
+    mem_st_sector5,
+    mem_st_sector6,
+    mem_st_sector7,
+    mem_st_sector8,
+    mem_st_sector9,
+    mem_st_sector10,
+    mem_st_sector11,
+    mem_st_system,
+    mem_st_otp_area,
+    mem_st_option_bytes,
+    mem_st_all,
 } stm32_mem_sectors;
 
+#define STM32_MEM_UNIT_NAMES                                                                                           \
+    "Sector 0", "Sector 1", "Sector 2", "Sector 3", "Sector 4", "Sector 5", "Sector 6", "Sector 7", "Sector 8",        \
+        "Sector 9", "Sector 10", "Sector 11", "System Memory", "OTP Area", "Option Bytes", "all"
 
-#define STM32_MEM_UNIT_NAMES "Sector 0", "Sector 1", "Sector 2", "Sector 3", \
-  "Sector 4", "Sector 5", "Sector 6", "Sector 7", "Sector 8", "Sector 9", \
-  "Sector 10", "Sector 11", "System Memory", "OTP Area", "Option Bytes", "all"
+#define STM32_READ_PROT_ERROR -10
 
-#define STM32_READ_PROT_ERROR   -10
+int32_t stm32_erase_flash (dfu_device_t *device, bool quiet);
+/*  mass erase flash
+ *  device  - the usb_dev_handle to communicate with
+ *  returns status DFU_STATUS_OK if ok, anything else on error
+ */
 
+int32_t stm32_page_erase (dfu_device_t *device, uint32_t address, bool quiet);
+/* erase a page of memory (provide the page address) */
 
-int32_t stm32_erase_flash( dfu_device_t *device, bool quiet );
-  /*  mass erase flash
-   *  device  - the usb_dev_handle to communicate with
-   *  returns status DFU_STATUS_OK if ok, anything else on error
-   */
+int32_t stm32_start_app (dfu_device_t *device, bool quiet);
+/* Reset the registers to default reset values and start application
+ */
 
-int32_t stm32_page_erase( dfu_device_t *device, uint32_t address,
-    bool quiet );
-  /* erase a page of memory (provide the page address) */
+int32_t stm32_read_flash (dfu_device_t *device, intel_buffer_in_t *buin, uint8_t mem_segment, const bool quiet);
+/* read the flash from buin->info.data_start to data_end and place
+ * in buin.data. mem_segment is the segment of memory from the
+ * stm32_memory_unit_enum.
+ */
 
-int32_t stm32_start_app( dfu_device_t *device, bool quiet );
-  /* Reset the registers to default reset values and start application
-   */
+int32_t stm32_write_flash (dfu_device_t *device, intel_buffer_out_t *bout, const bool eeprom, const bool force,
+                           const bool hide_progress);
+/* Flash data from the buffer to the main program memory on the device.
+ * buffer contains the data to flash where buffer[0] is aligned with memory
+ * address zero (which could be inside the bootloader and unavailable).
+ * buffer[start / end] correspond to the start / end of available memory
+ * outside the bootloader.
+ * flash_page_size is the size of flash pages - used for alignment
+ * eeprom bool tells if you want to flash to eeprom or flash memory
+ * hide_progress bool sets whether to display progress
+ */
 
-int32_t stm32_read_flash( dfu_device_t *device,
-              intel_buffer_in_t *buin,
-              uint8_t mem_segment,
-              const bool quiet);
-  /* read the flash from buin->info.data_start to data_end and place
-   * in buin.data. mem_segment is the segment of memory from the
-   * stm32_memory_unit_enum.
-   */
+int32_t stm32_get_commands (dfu_device_t *device);
+/* @brief get the commands list, should be length 4
+ * @param device pointer
+ * @return 0 on success
+ */
 
-int32_t stm32_write_flash( dfu_device_t *device, intel_buffer_out_t *bout,
-    const bool eeprom, const bool force, const bool hide_progress );
-  /* Flash data from the buffer to the main program memory on the device.
-   * buffer contains the data to flash where buffer[0] is aligned with memory
-   * address zero (which could be inside the bootloader and unavailable).
-   * buffer[start / end] correspond to the start / end of available memory
-   * outside the bootloader.
-   * flash_page_size is the size of flash pages - used for alignment
-   * eeprom bool tells if you want to flash to eeprom or flash memory
-   * hide_progress bool sets whether to display progress
-   */
+int32_t stm32_get_configuration (dfu_device_t *device);
+/* @brief get the configuration structure
+ * @param device pointer
+ * @return 0 on success, negative for error
+ */
 
-int32_t stm32_get_commands( dfu_device_t *device );
-  /* @brief get the commands list, should be length 4
-   * @param device pointer
-   * @return 0 on success
-   */
-
-int32_t stm32_get_configuration( dfu_device_t *device );
-  /* @brief get the configuration structure
-   * @param device pointer
-   * @return 0 on success, negative for error
-   */
-
-int32_t stm32_read_unprotect( dfu_device_t *device, bool quiet );
-  /* @brief unprotect the device (triggers a mass erase)
-   * @param device pointer
-   * @return 0 on success
-   */
-
-
+int32_t stm32_read_unprotect (dfu_device_t *device, bool quiet);
+/* @brief unprotect the device (triggers a mass erase)
+ * @param device pointer
+ * @return 0 on success
+ */
 
 #if 0
 int32_t stm32_read_config( dfu_device_t *device,
@@ -133,7 +125,7 @@ int32_t stm32_user( dfu_device_t *device, intel_buffer_out_t *bout );
 void stm32_print_device_info( FILE *stream, stm32_device_info_t *info );
 #endif
 
-#endif  /* __STM32_H__ */
+#endif /* __STM32_H__ */
 
 // cSpell:ignore shiftwidth
 // vim: shiftwidth=2

--- a/src/util.c
+++ b/src/util.c
@@ -23,17 +23,16 @@
 
 #include "util.h"
 
-extern int debug;       /* defined in main.c */
+extern int debug; /* defined in main.c */
 
-void dfu_debug( const char *file, const char *function, const int line,
-                const int level, const char *format, ... )
-{
-    if( level < debug ) {
+void
+dfu_debug (const char *file, const char *function, const int line, const int level, const char *format, ...) {
+    if (level < debug) {
         va_list va_arg;
 
-        va_start( va_arg, format );
-        fprintf( stderr, "%s:%d: ", file, line );
-        vfprintf( stderr, format, va_arg );
-        va_end( va_arg );
+        va_start (va_arg, format);
+        fprintf (stderr, "%s:%d: ", file, line);
+        vfprintf (stderr, format, va_arg);
+        va_end (va_arg);
     }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -23,6 +23,5 @@
 
 #include <stdarg.h>
 
-void dfu_debug( const char *file, const char *function, const int line,
-                const int level, const char *format, ... );
+void dfu_debug (const char *file, const char *function, const int line, const int level, const char *format, ...);
 #endif


### PR DESCRIPTION
I'd like to implement automated code quality checks.

These are some `clang-format` settings I thought seemed reasonable to enforce. Every time code is pushed, it will be checked against this standard.

We could also encourage using git hooks to ensure code is formatted before committing in the readme.

I'd like to finish the libdfu stuff first but I thought I'd start this discussion.