### PR TITLE
Use clang-tidy to lint code

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,29 @@
+name: Check code quality
+
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Check code quality with clang-tidy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt-get install -y libusb-1.0-0-dev
+
+      - name: bootstrap
+        run: ./bootstrap.sh
+
+      - name: configure
+        run: ./configure --disable-dependency-tracking ${{ steps.override.outputs.override }}
+
+      - name: Check code quality of all source files
+        run: clang-tidy src/*.h src/*.c -- -Isrc


### PR DESCRIPTION
Starting to look at fixing possible issues detected by [`clang-tidy`](https://clang.llvm.org/extra/clang-tidy)