### PR TITLE
arguments.c: add --erase-first argument to flash for devices with lockbits set

### DIFF
--- a/src/arguments.c
+++ b/src/arguments.c
@@ -364,6 +364,7 @@ static void usage()
                      "                     [--suppress-validation]\n"
                      "                     [--suppress-bootloader-mem]\n"
                      "                     [--validate-first]\n"
+                     "                     [--erase-first]\n"
                      "                     [--ignore-outside]\n"
                      "                     [--serial=hexdigits:offset] {file|STDIN}\n" );
     fprintf( stderr, "        setsecure\n" );
@@ -596,6 +597,24 @@ static int32_t assign_global_options( struct programmer_arguments *args,
                 case com_eflash:
                 case com_user:
                     args->com_flash_data.validate_first = 1;
+                    break;
+                default:
+                    /* not supported. */
+                    return -1;
+            }
+            break;
+        }
+    }
+
+    /* Find '--erase-first' if it is here - even though it is not
+     * used by all this is easier. */
+    for( i = 0; i < argc; i++ ) {
+        if( 0 == strcmp("--erase-first", argv[i]) ) {
+            *argv[i] = '\0';
+
+            switch( args->command ) {
+                case com_flash:
+                    args->com_flash_data.erase_first = 1;
                     break;
                 default:
                     /* not supported. */

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -225,6 +225,7 @@ struct programmer_arguments {
                                      bootloader - force overwrite required */
             bool validate_first; /* Do a validate before flashing */
             bool ignore_outside; /* Ignore validate errors outside region */
+            bool erase_first; /* Erase flash before writing */
             enum atmel_memory_unit_enum segment;
         } com_flash_data;
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -383,6 +383,19 @@ static int32_t execute_flash( dfu_device_t *device,
     if( mem_type == mem_user ) {
         result = atmel_user( device, &bout );
     } else {
+        if ( 1 == args->com_flash_data.erase_first ) {
+            if( args->device_type & GRP_STM32 ) {
+                result = stm32_erase_flash( device, args->quiet );
+            } else {
+                result = atmel_erase_flash( device, ATMEL_ERASE_ALL, args->quiet );
+            }
+
+            if( 0 != result ) {
+                DEBUG( "Error erasing flash. (err %d)\n", result );
+                return result;
+            }
+        }
+
         if( args->device_type & GRP_STM32 ) {
             result = stm32_write_flash( device, &bout,
                     mem_type == mem_eeprom ? true : false,


### PR DESCRIPTION
ATxmega devices have lockbits efuses, which can be used to limit what flash areas can be read/written.  The Atmel DFU bootloader checks the lock bits at `SET_CONFIGURATION` time, and will reject a program request unless an erase has been sent.

`SET_CONFIGURATION` is unfortunately triggered every time dfu-programmer is run (from `dfu_device_init()`), so it doesn't work to do:

```bash
dfu-programmer <device> erase
dfu-programmer <device> flash
```

As the lockbits are again read at the start of the flash command.  As a workaround, add an `--erase-first` argument to the flash command to trigger a full erase before flashing.