### PR TITLE
Makefile.am: include update-bash-completion.sh in release tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,4 +10,4 @@ all: bash-completion
 EXTRA_DIST = bootstrap.sh
 EXTRA_DIST += dfu_completion
 EXTRA_DIST += fedora/10-dfu-programmer.fdi fedora/dfu-programmer.spec
-
+EXTRA_DIST += update-bash-completion.sh


### PR DESCRIPTION
Commit d08f2efabc1 (Generate bash_completion file with make, not bootstrap) added an update-bash-completion.sh script and called it from the Makefile, but forgot to add it to EXTRA_DIST, so it is not present in the release tarballs, breaking the build.