### PR TITLE
Bump minor version for release with new "--erase-first" option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([dfu-programmer],[1.0.0],[https://github.com/dfu-programmer/dfu-programmer/issues],[],[https://dfu-programmer.github.io/])
+AC_INIT([dfu-programmer],[1.1.0],[https://github.com/dfu-programmer/dfu-programmer/issues],[],[https://dfu-programmer.github.io/])
 AC_CONFIG_AUX_DIR(m4)
 AC_CONFIG_SRCDIR([src/atmel.c])
 AM_INIT_AUTOMAKE


### PR DESCRIPTION
Following [Sematic Versioning](https://semver.org/#semantic-versioning-200), I'd like to bump the minor version and push a new release with the newly merged feature in #90. Please approve. I'll merge and create a new tag `v1.1.0` pointing to this new version. That should cut new binaries for all.